### PR TITLE
add pypy 3.8 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python: [ '3.8', '3.9', '3.10' ]
+        python: [ '3.8', '3.9', '3.10', 'pypy3.8' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
newer versions are not available via setup-python at the moment