### PR TITLE
Include pyptr.h in sdist, allow conda build config via CXX env vars.

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -34,7 +34,7 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         include:
           - os: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+            container: quay.io/pypa/manylinux2014_x86_64  # https://github.com/pypa/manylinux
           - os: macos-latest
             python_version: 3.8
             upload_source: true   # just need ONE of them to do it

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         python_version: ['3.8', '3.9', '3.10']
         include:
           - os: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+            container: quay.io/pypa/manylinux2014_x86_64 # https://github.com/pypa/manylinux
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,32 @@ jobs:
 
     - name: run tests
       run: python3 -m pytest
+
+  # Run a manylinux wheel build to verify build configuration
+  test-build-wheel-manylinux:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        python_version: ['3.8', '3.9', '3.10']
+        include:
+          - os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up python
+        run: |
+          PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -d -1 /opt/python/cp$PYV*/bin | head -n 1 >> $GITHUB_PATH
+          cat $GITHUB_PATH
+      - name: install dependencies
+        run: |
+          python3 -m pip install setuptools wheel twine
+      - name: build wheel
+        run: |
+            python3 setup.py bdist_wheel
+      - name: run auditwheel for manylinux
+        run: |
+          auditwheel repair dist/*.whl
+          rm -f dist/*.whl
+          mv wheelhouse/*.whl dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 # dev-build.txt is only present on development builds
 include dev-build.txt
+
+# pyptr.h is required in source distributions
+include pyptr.h

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,6 @@ def limited_api_args():
     return []
 
 
-if sys.platform == "linux" and "CXX" not in os.environ:
-    # distutils.sysconfig, called by standard build_ext,
-    # reads CXX to set c++ compiler toolchain
-    #
-    # Set to g++ in linux env if not otherwise specified
-    os.environ["CXX"] = "g++"
-
 probe = setuptools.extension.Extension(
     'slipcover.probe',
     sources=['probe.cxx'],

--- a/setup.py
+++ b/setup.py
@@ -58,21 +58,13 @@ def limited_api_args():
 #    return ['-DPy_LIMITED_API=0x030a0000']
     return []
 
-class CppExtension(build_ext):
-    def build_extensions(self):
-        if sys.platform == "linux":
-            self.compiler.compiler_so[0] = "g++"
-            self.compiler.compiler_cxx[0] = "g++"
-            self.compiler.linker_so[0] = "g++"
-        build_ext.build_extensions(self)
-
 probe = setuptools.extension.Extension(
             'slipcover.probe',
             sources=['probe.cxx'],
             extra_compile_args=cxx_version('c++17') + platform_compile_args() + limited_api_args(),
             extra_link_args=platform_link_args(),
             py_limited_api=bool(limited_api_args()),
-            language='C++'
+            language='c++'
 )
 
 
@@ -93,7 +85,6 @@ setuptools.setup(
     install_requires=[
         "tabulate"
     ],
-    cmdclass={"build_ext": CppExtension},
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ def platform_compile_args():
     if flags := os.environ.get("CXXFLAGS", "").split():
         return flags
 
+    # Otherwise default to a multi-arch build
     if sys.platform == 'darwin':
         return "-arch x86_64 -arch arm64 -arch arm64e".split()
     if sys.platform == 'win32':

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import setuptools
 from setuptools.command.build_ext import build_ext
 import sys
+import os
 from pathlib import Path
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-from setuptools.command.build_ext import build_ext
 import sys
 import os
 from pathlib import Path


### PR DESCRIPTION
Minor fixes required for builds under conda.

* Add pyptr.h to manifest, currently missing from sdist.
* Fix typo in `setup.py` extension definitions, extension wasn't being detected as `c++`.
