### PR TITLE
Fix divide by zero error when test file is empty

### DIFF
--- a/src/slipcover/slipcover.py
+++ b/src/slipcover/slipcover.py
@@ -433,7 +433,10 @@ class Slipcover:
 
                     pct = 100*(exec_l+exec_b)/(exec_l+miss_l+exec_b+miss_b)
                 else:
-                    pct = 100*exec_l/(exec_l+miss_l)
+                    if (exec_l+miss_l) == 0:
+                        pct = 100
+                    else:
+                        pct = 100*exec_l/(exec_l+miss_l)
 
                 yield [f, exec_l+miss_l, miss_l,
                        *([exec_b+miss_b, miss_b] if self.branch else []),


### PR DESCRIPTION
I had an empty `__init__.py` file in my `tests` folder throwing a divide by zero error when running `python -m slipcover -m pytest`

This is a somewhat opinionated fix, as I consider an empty file to be 100% covered. Feel free to nitpick!