### PR TITLE
Add tox test config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 build/
 dist/
 .coverage
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+# content of: tox.ini , put in same dir as setup.py
+[tox]
+envlist = py38,py39,py310,py311
+
+# tox-wheel: supports bdist install for future src layout
+# tox-conda: install python interpreter versions via conda
+requires =
+  tox-wheel
+  tox-conda
+
+[testenv]
+# include conda-forge channel to fetch python 3.11
+conda_channels = conda-forge
+
+# pytest command runs from root checkout
+# install via `setup.py develop` so build artifact is placed in source tree
+usedevelop = true
+
+# when package switches to src layout, remove usedevelop and switch to wheel install
+# wheel = true
+
+deps = pytest
+commands =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310
 
 # tox-wheel: supports bdist install for future src layout
 # tox-conda: install python interpreter versions via conda


### PR DESCRIPTION
Add a basic tox configuration to execute tests against
multiple python versions in a local development environment.

Tox is used to initialize an isolated python environment for tests,
including any required external dependencies.

This config uses [tox-conda] to support multiple python interpreter
versions.

[tox]: https://tox.wiki/en/rewrite/installation.html
[tox-conda]: https://github.com/tox-dev/tox-conda 

------------

Possible options:

- [ ] Add tox notes to README.md contributor instructions.
- [ ] Convert actions workflows to use tox for different python versions.

- Add basic tox config for different python versions
- Remove py311 from tox env list, currently broken
