### PR TITLE
Hardcode show_contexts flag to False in json report

### DIFF
--- a/src/slipcover/slipcover.py
+++ b/src/slipcover/slipcover.py
@@ -415,6 +415,7 @@ class Slipcover:
                         'version': VERSION,
                         'timestamp': datetime.datetime.now().isoformat(),
                         'branch_coverage': self.branch,
+                        'show_contexts': False,
                     },
                     'files': files,
                     'summary': summary

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -271,6 +271,7 @@ def test_meta_in_results(do_branch):
     assert sc.VERSION == meta['version']
     assert 'timestamp' in meta
     assert do_branch == meta['branch_coverage']
+    assert meta['show_contexts'] is False
 
 
 def test_get_coverage_detects_lines():


### PR DESCRIPTION
Hi. I tried few days ago to upload json coverage to codecov. I got the following the error: "the report is not usuable". After a deeper look into the codecov code, I found the error. Codecov is infering the coverage type from few elements in the file. For json coverage file, the code is the following : https://github.com/codecov/worker/blob/861583604119da9c607b588055e4f175a784a103/services/report/languages/pycoverage.py#L22

This show_contexts flag was the missing element, by adding it in the coverage file, codecov is able to recognize my report and display the coverage correctly. The measure context feature coverage py is a not supported slipcover feature. I'm not using this feature (I didn't know about it actually).
My proposal, for now, would be to hardcode this flag to False to be able to upload report to codecov.