### PR TITLE
refactor: improve file matcher coding

### DIFF
--- a/src/slipcover/importer.py
+++ b/src/slipcover/importer.py
@@ -82,9 +82,9 @@ class FileMatcher:
             if filename == 'built-in': return False     # can't instrument
             filename = Path(filename)
 
-        filename = filename.resolve()
-
         if filename.suffix in ('.pyd', '.so'): return False  # can't instrument DLLs
+
+        filename = filename.resolve()
 
         if self.omit:
             from fnmatch import fnmatch

--- a/src/slipcover/importer.py
+++ b/src/slipcover/importer.py
@@ -8,6 +8,15 @@ import sysconfig
 from importlib.abc import MetaPathFinder, Loader
 from importlib import machinery
 
+
+if sys.version_info[0:2] < (3,9):
+    # Path.is_relative_to is new in Python 3.9
+    def is_relative_to(self: Path, other: str) -> bool:
+        other = Path(other)
+        return other == self or other in self.parents
+    setattr(Path, 'is_relative_to', is_relative_to)
+
+
 class SlipcoverLoader(Loader):
     def __init__(self, sci: Slipcover, orig_loader: Loader, origin: str):
         self.sci = sci                  # Slipcover object measuring coverage


### PR DESCRIPTION
We propose using `sysconfig` for a more reliable way of retrieving the location of standard library and site packages pure Python sources.

Note on testing: this PR was prepared on GitHub, so I haven't had the chance to test it yet 🤞 