### PR TITLE
fixed missing coverage for one-line lambdas in 3.11

### DIFF
--- a/src/slipcover/slipcover.py
+++ b/src/slipcover/slipcover.py
@@ -34,8 +34,10 @@ if sys.version_info >= (3,11):
     _op_RETURN_GENERATOR = dis.opmap["RETURN_GENERATOR"]
 
     def findlinestarts(co: types.CodeType):
-        for off, line in dis.findlinestarts(co):
-            if line and co.co_code[off] not in (_op_RESUME, _op_RETURN_GENERATOR):
+        last_line = None
+        for off, _, line in co.co_lines():
+            if line and line != last_line and co.co_code[off] not in (_op_RESUME, _op_RETURN_GENERATOR):
+                last_line = line
                 yield off, line
 
 else:


### PR DESCRIPTION
For issue https://github.com/plasma-umass/slipcover/issues/59 : 

One-line lambdas are missing coverage probes (3.11).

If a lambda is not executed, we don't get any indication.
This is due to interplay between dis.findlinestarts() which removes duplicated, and slipcover.findlinestarts() which ignores noop-like opcode of RESUME and RETURN_GENERATOR.
