### PR TITLE
Add `--sigterm` flag

### DIFF
--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -8,6 +8,7 @@ import atexit
 import platform
 import functools
 import os
+import signal
 import tempfile
 import json
 import warnings
@@ -159,6 +160,7 @@ def main():
     ap.add_argument('--threshold', type=int, default=50, metavar="T",
                     help="threshold for de-instrumentation (if not immediate)")
     ap.add_argument('--missing-width', type=int, default=80, metavar="WIDTH", help="maximum width for `missing' column")
+    ap.add_argument('--sigterm', action='store_true', help="if true, register a SIGTERM signal handler to capture data when the process ends due to a SIGTERM signal.")
 
     # intended for slipcover development only
     ap.add_argument('--silent', action='store_true', help=argparse.SUPPRESS)
@@ -240,6 +242,9 @@ def main():
                 printit(coverage, sys.stdout)
 
     atexit.register(sci_atexit)
+
+    if args.sigterm:
+        signal.signal(signal.SIGTERM, lambda *_: sci_atexit())
 
     if args.script:
         # python 'globals' for the script being executed

--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -243,8 +243,14 @@ def main():
 
     atexit.register(sci_atexit)
 
-    if args.sigterm:
-        signal.signal(signal.SIGTERM, lambda *_: sci_atexit())
+    # Windows doesn't have a SIGTERM signal.
+    if args.sigterm and platform.system() != 'Windows':
+        def sci_sigterm_atexit(signum, frame):
+            sci_atexit()
+            # we have to exit here, otherwise the process won't stop.
+            sys.exit(0)
+
+        signal.signal(signal.SIGTERM, sci_sigterm_atexit)
 
     if args.script:
         # python 'globals' for the script being executed

--- a/src/slipcover/config.py
+++ b/src/slipcover/config.py
@@ -115,6 +115,7 @@ _BOOL_KEYS = {
     "pretty-print",
     "immediate",
     "skip-covered",
+    "sigterm",
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,10 +169,16 @@ def _make_args(**kwargs):
         out=None, source=None, omit=None,
         immediate=False, skip_covered=False, fail_under=0,
         threshold=50, missing_width=80, silent=False, dis=False,
-        debug=False, dont_wrap_pytest=False,
+        debug=False, dont_wrap_pytest=False, sigterm=False,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
+
+
+def test_apply_config_sigterm():
+    args = _make_args()
+    apply_config({"sigterm": True}, args)
+    assert args.sigterm is True
 
 
 def test_apply_config_lcov_keys():

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1804,3 +1804,92 @@ def test_lcov_flag_with_merge(cov_merge_fixture):
     assert 'DA:6,1' in da_lines
     assert 'DA:9,0' in da_lines
     assert 'end_of_record' in lines
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='SIGTERM is Unix-specific')
+def test_sigterm_top_level_writes_single_correct_report(tmp_path, monkeypatch):
+    """A SIGTERM'd top-level process must produce exactly one coverage
+    report. The original bug called sci_atexit() manually and then let
+    atexit run it again via sys.exit(), printing the table twice.
+    """
+    import signal
+    import time
+
+    monkeypatch.chdir(tmp_path)
+    script = tmp_path / "script.py"
+    script.write_text(dedent("""\
+        import time
+        x = 1
+        time.sleep(10)
+        y = 2  # must never execute -- process is killed during sleep
+    """))
+
+    proc = subprocess.Popen(
+        [sys.executable, '-m', 'slipcover', '--sigterm', 'script.py'],
+        cwd=tmp_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+
+    time.sleep(1)  # let slipcover start up and reach the sleep
+    proc.send_signal(signal.SIGTERM)
+    stdout, stderr = proc.communicate(timeout=10)
+
+    assert proc.returncode == 0, f"stdout={stdout}\nstderr={stderr}"
+    # the report table's header appears exactly once per report -- the
+    # original bug printed it twice
+    assert stdout.count('#lines') == 1, f"expected exactly one report, got:\n{stdout}"
+    assert 'script.py' in stdout
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='SIGTERM/fork are Unix-specific')
+def test_sigterm_forked_child_writes_partial_coverage_safely(tmp_path, monkeypatch):
+    """A forked child killed by SIGTERM must exit through the shimmed
+    os._exit() (writing its own partial coverage to a tempfile for the
+    parent to merge) rather than racing the parent through the top-level
+    report path -- exercised via the real --sigterm flag and a real
+    os.fork() in the target script, not by calling internal functions
+    directly.
+    """
+    import os
+    import signal
+    import time
+
+    monkeypatch.chdir(tmp_path)
+    script = tmp_path / "script.py"
+    script.write_text(dedent("""\
+        import os, time
+
+        pid = os.fork()
+        if pid == 0:
+            x = 1
+            time.sleep(10)
+            y = 2  # must never execute -- child is killed during sleep
+        else:
+            with open("child_pid.txt", "w") as f:
+                f.write(str(pid))
+            os.waitpid(pid, 0)
+    """))
+
+    proc = subprocess.Popen(
+        [sys.executable, '-m', 'slipcover', '--sigterm', '--json', '--out', 'out.json', 'script.py'],
+        cwd=tmp_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+
+    pid_file = tmp_path / "child_pid.txt"
+    for _ in range(100):  # up to ~5s
+        if pid_file.exists():
+            break
+        time.sleep(0.05)
+    else:
+        proc.kill()
+        pytest.fail("forked child never started")
+
+    child_pid = int(pid_file.read_text())
+    os.kill(child_pid, signal.SIGTERM)
+
+    stdout, stderr = proc.communicate(timeout=10)
+    assert proc.returncode == 0, f"stdout={stdout}\nstderr={stderr}"
+
+    cov = json.loads((tmp_path / "out.json").read_text())
+    file_cov = cov['files']['script.py']
+    assert 5 in file_cov['executed_lines']       # x = 1, in the child
+    assert 7 not in file_cov['executed_lines']   # y = 2, never reached


### PR DESCRIPTION
Adds a `--sigterm` flag (matching [coverage.py's `sigterm` flag](https://coverage.readthedocs.io/en/latest/config.html#run-sigterm)) to still write the coverage output if a `SIGTERM` signal is sent.

Helpful for using slipcover in e.g. docker containers.

Tested with a simple `while True: ...` script and then a `kill -SIGTERM`. I'm not too familiar with what sort of cleanup may be necessary for more complex cases, so I'd welcome any suggestions on how to truly gracefully exit.

Also, this currently ignores `--fail-under`, since it exits immediately instead. I'm happy to update it to e.g. raise an exception that is caught by a context manager surrounding the `runpy` / `exec` calls, so that the normal flow in `__main__` afterwards is maintained. I chose not to for now, since the `atexit` isn't currently doing that either.

Thanks for creating/maintaining this project!

---

**Update:** fixed two bugs in the original handler: it called `sci_atexit()` manually and then `sys.exit(0)`, which re-triggered the same already-registered `atexit` handler a second time, double-writing the report; and a forked child inheriting the handler went through that same top-level path instead of the already-shimmed `os._exit()`, racing the real parent for `--out` and silently dropping the child's coverage on merge. Added two integration tests exercising real `--sigterm` + real signal delivery (including a real forked child) end to end. The `--fail-under` caveat above is still accurate and unaddressed.
