### PR TITLE
Add `percent_covered_display` to the global summary JSON output

### DIFF
--- a/src/slipcover/slipcover.py
+++ b/src/slipcover/slipcover.py
@@ -203,6 +203,7 @@ def add_summaries(cov: dict) -> None:
             g_den += den
 
     g_summary['percent_covered'] = 100.0 if g_den == 0 else 100*g_nom/g_den
+    g_summary['percent_covered_display'] = str(int(round(g_summary['percent_covered'], 0)))
     cov['summary'] = g_summary
 
 


### PR DESCRIPTION
This will improve support for drop-in replacement of `Coverage` where tooling relies on `percent_covered_display` for dashboards, badges, etc.

See https://github.com/nedbat/coveragepy/blob/50dfc7bb718b81ba92ba8f0c5697bf9192c6e3f2/coverage/jsonreport.py#L51