### PR TITLE
Add support for pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,31 @@ which starts `pytest`, passing it any options (`-x -v` in this example)
 after the module name.
 No plug-in is required for pytest.
 
+### Configuration via `pyproject.toml`
+Instead of passing options on every command invocation, you can store them
+in your project's `pyproject.toml` under the `[tool.slipcover]` section.
+SlipCover automatically discovers the nearest `pyproject.toml` by walking up
+from the current working directory.
+
+```toml
+[tool.slipcover]
+branch = true
+source = "src"
+omit = "tests/*"
+fail-under = 80.0
+json = true
+pretty-print = true
+skip-covered = true
+out = "coverage.json"
+threshold = 75
+missing-width = 120
+xml-package-depth = 3
+```
+
+Every command-line flag has a matching key (use hyphens, as shown above).
+Command-line arguments always take precedence over values in `pyproject.toml`,
+so you can override any setting on a per-run basis.
+
 ## Usage example
 ```console
 $ python3 -m slipcover -m pytest

--- a/README.md
+++ b/README.md
@@ -100,21 +100,26 @@ from the current working directory.
 ```toml
 [tool.slipcover]
 branch = true
-source = "src"
-omit = "tests/*"
+source = "src"        # or ["src", "lib"]
+omit = "tests/*"       # or ["tests/*", "*.pyc"]
 fail-under = 80.0
 json = true
+xml = false
 pretty-print = true
 skip-covered = true
+immediate = false
 out = "coverage.json"
 threshold = 75
 missing-width = 120
 xml-package-depth = 3
 ```
 
-Every command-line flag has a matching key (use hyphens, as shown above).
-Command-line arguments always take precedence over values in `pyproject.toml`,
-so you can override any setting on a per-run basis.
+Most command-line flags have a matching key (use hyphens, as shown above);
+`source` and `omit` also accept a TOML array instead of a single
+comma-separated string. `--merge`, `-m`/module, the script argument, `--version`,
+and `--help` are per-invocation choices rather than settings, so they aren't
+configurable this way. Command-line arguments always take precedence over
+values in `pyproject.toml`, so you can override any setting on a per-run basis.
 
 ## Usage example
 ```console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 ]
 requires-python = ">=3.8,<3.15"
 dependencies = [
-    "tabulate"
+    "tabulate",
+    "tomli; python_version < '3.11'"
 ]
 
 [project.scripts]

--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -150,8 +150,40 @@ def merge_files(args, base_path):
     return 0
 
 
+def _detect_explicit_args(ap, argv):
+    """Returns the set of argparse dest names explicitly provided on the command line."""
+    import argparse
+
+    explicit = set()
+
+    class _Track(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            explicit.add(self.dest)
+            setattr(namespace, self.dest, values)
+
+    shadow = argparse.ArgumentParser(add_help=False)
+    for action in ap._actions:
+        if action.option_strings:
+            kwargs = {
+                "dest": action.dest,
+                "nargs": action.nargs,
+                "default": action.default,
+            }
+            if isinstance(action, argparse._StoreTrueAction):
+                kwargs["nargs"] = 0
+                kwargs["const"] = True
+            elif isinstance(action, argparse._VersionAction):
+                continue
+            kwargs["action"] = _Track
+            shadow.add_argument(*action.option_strings, **kwargs)
+
+    shadow.parse_known_args(argv)
+    return explicit
+
+
 def main():
     import argparse
+    from slipcover.config import read_config, apply_config
 
     #
     # The intended usage is:
@@ -195,12 +227,27 @@ def main():
     g.add_argument('script', nargs='?', type=Path, help="the script to run")
     ap.add_argument('script_or_module_args', nargs=argparse.REMAINDER)
 
+    # Figure out which CLI flags were explicitly provided, so that
+    # pyproject.toml values don't override them.
+    if '-m' in sys.argv:
+        minus_m = sys.argv.index('-m')
+        cli_argv = sys.argv[1:minus_m+2]
+    else:
+        cli_argv = sys.argv[1:]
+
+    explicit_args = _detect_explicit_args(ap, cli_argv)
+
     if '-m' in sys.argv: # work around exclusive group not handled properly
         minus_m = sys.argv.index('-m')
         args = ap.parse_args(sys.argv[1:minus_m+2])
         args.script_or_module_args = sys.argv[minus_m+2:]
     else:
         args = ap.parse_args(sys.argv[1:])
+
+    # Apply [tool.slipcover] from pyproject.toml; CLI flags take precedence
+    config = read_config()
+    if config:
+        apply_config(config, args, explicit_args)
 
 
     base_path = Path(args.script).resolve().parent if args.script \

--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -245,9 +245,13 @@ def main():
         args = ap.parse_args(sys.argv[1:])
 
     # Apply [tool.slipcover] from pyproject.toml; CLI flags take precedence
-    config = read_config()
-    if config:
-        apply_config(config, args, explicit_args)
+    try:
+        config = read_config()
+        if config:
+            apply_config(config, args, explicit_args)
+    except (ValueError, TypeError) as e:
+        print(f"slipcover: error in pyproject.toml configuration: {e}", file=sys.stderr)
+        return 1
 
 
     base_path = Path(args.script).resolve().parent if args.script \

--- a/src/slipcover/config.py
+++ b/src/slipcover/config.py
@@ -1,0 +1,125 @@
+"""Read and apply [tool.slipcover] configuration from pyproject.toml."""
+
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+# Markers that indicate a project root; stop climbing here.
+_ROOT_MARKERS = frozenset({".git", ".hg", ".svn", "setup.py", "setup.cfg"})
+
+# Maximum number of parent directories to walk up from the start.
+_MAX_WALK = 3
+
+
+def find_pyproject(start=None):
+    """Walks up from 'start' (default cwd) looking for pyproject.toml.
+
+    The search stops and returns None when any of these boundaries is
+    reached without finding the file:
+
+    - a directory containing a VCS/project root marker
+      (.git, .hg, .svn, setup.py, setup.cfg)
+    - the user's home directory
+    - more than _MAX_WALK parent directories have been visited
+    """
+    if start is None:
+        start = Path.cwd()
+    start = start.resolve()
+
+    home = Path.home()
+
+    for depth, directory in enumerate((start, *start.parents)):
+        candidate = directory / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+
+        # Don't climb above a project root, the user's home directory,
+        # or more than _MAX_WALK levels.
+        if (depth >= _MAX_WALK
+                or directory == home
+                or any((directory / m).exists() for m in _ROOT_MARKERS)):
+            break
+
+    return None
+
+
+def read_config(path=None):
+    """Returns the [tool.slipcover] table from a pyproject.toml.
+
+    If 'path' is None, find_pyproject() is used to locate the file.
+    Returns an empty dict when no file is found or the section is absent.
+    """
+    if path is None:
+        path = find_pyproject()
+
+    if path is None:
+        return {}
+
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    return data.get("tool", {}).get("slipcover", {})
+
+
+# Boolean flags (store_true in CLI)
+_BOOL_KEYS = {
+    "branch",
+    "json",
+    "pretty-print",
+    "xml",
+    "immediate",
+    "skip-covered",
+    "silent",
+    "dis",
+    "debug",
+    "dont-wrap-pytest",
+}
+
+# Keys that take a value
+_VALUE_KEYS = {
+    "out": Path,
+    "source": str,
+    "omit": str,
+    "fail-under": float,
+    "threshold": int,
+    "missing-width": int,
+    "xml-package-depth": int,
+}
+
+
+def apply_config(config, parsed_args, explicit_args=None):
+    """Merges config values into parsed_args.
+
+    Keys whose dest name appears in 'explicit_args' are skipped so that
+    command-line flags always take precedence over the config file.
+
+    Raises TypeError if a boolean key has a non-boolean value.
+    Emits a UserWarning for unrecognised keys.
+    """
+    if explicit_args is None:
+        explicit_args = set()
+
+    for key, value in config.items():
+        dest = key.replace("-", "_")
+
+        # CLI flags always win
+        if dest in explicit_args:
+            continue
+
+        if key in _BOOL_KEYS:
+            if not isinstance(value, bool):
+                raise TypeError(
+                    f"[tool.slipcover] key '{key}' must be a boolean, got {type(value).__name__}"
+                )
+            setattr(parsed_args, dest, value)
+
+        elif key in _VALUE_KEYS:
+            setattr(parsed_args, dest, _VALUE_KEYS[key](value))
+
+        else:
+            import warnings
+            warnings.warn(f"Unknown [tool.slipcover] key: '{key}'")

--- a/src/slipcover/config.py
+++ b/src/slipcover/config.py
@@ -118,6 +118,11 @@ def apply_config(config, parsed_args, explicit_args=None):
             setattr(parsed_args, dest, value)
 
         elif key in _VALUE_KEYS:
+            # TOML's idiomatic way to express multiple values is an array;
+            # join it the way --source/--omit's comma-separated CLI form
+            # expects, rather than stringifying the Python list itself.
+            if key in ("source", "omit") and isinstance(value, list):
+                value = ",".join(str(v) for v in value)
             setattr(parsed_args, dest, _VALUE_KEYS[key](value))
 
         else:

--- a/src/slipcover/config.py
+++ b/src/slipcover/config.py
@@ -65,7 +65,9 @@ def read_config(path=None):
     return data.get("tool", {}).get("slipcover", {})
 
 
-# Boolean flags (store_true in CLI)
+# Boolean flags (store_true in CLI). Excludes --silent/--dis/--debug/
+# --dont-wrap-pytest: those are argparse.SUPPRESS'd, dev-only flags, not
+# part of the stable, user-facing config surface.
 _BOOL_KEYS = {
     "branch",
     "json",
@@ -73,10 +75,6 @@ _BOOL_KEYS = {
     "xml",
     "immediate",
     "skip-covered",
-    "silent",
-    "dis",
-    "debug",
-    "dont-wrap-pytest",
 }
 
 # Keys that take a value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,215 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+from slipcover.config import apply_config, find_pyproject, read_config
+
+
+def test_find_pyproject_in_cwd(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("")
+    assert find_pyproject(tmp_path) == tmp_path / "pyproject.toml"
+
+
+def test_find_pyproject_walks_up(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("")
+    child = tmp_path / "a" / "b" / "c"
+    child.mkdir(parents=True)
+    assert find_pyproject(child) == tmp_path / "pyproject.toml"
+
+
+def test_find_pyproject_returns_none(tmp_path):
+    child = tmp_path / "nowhere"
+    child.mkdir()
+    result = find_pyproject(child)
+    # might find the repo's own file if tmp_path is under the repo tree
+    assert result is None or result.name == "pyproject.toml"
+
+
+def test_find_pyproject_stops_at_vcs_root(tmp_path):
+    """Should not walk past a directory containing .git."""
+    # Place pyproject.toml above the VCS root — it should NOT be found.
+    (tmp_path / "pyproject.toml").write_text("")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()          # VCS root marker
+    child = project / "src"
+    child.mkdir()
+    assert find_pyproject(child) is None
+
+
+def test_find_pyproject_finds_file_at_vcs_root(tmp_path):
+    """pyproject.toml sitting right next to .git should still be found."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / "pyproject.toml").write_text("")
+    child = project / "src"
+    child.mkdir()
+    assert find_pyproject(child) == project / "pyproject.toml"
+
+
+def test_find_pyproject_stops_at_home(tmp_path, monkeypatch):
+    """Should not walk above the user's home directory."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    # Place pyproject.toml above the fake home — should NOT be found.
+    (tmp_path / "pyproject.toml").write_text("")
+    child = fake_home / "projects" / "foo"
+    child.mkdir(parents=True)
+    assert find_pyproject(child) is None
+
+
+def test_find_pyproject_stops_after_max_walk(tmp_path):
+    """Should not walk more than _MAX_WALK levels up."""
+    from slipcover.config import _MAX_WALK
+
+    # Build a chain deeper than _MAX_WALK and place pyproject.toml at the top.
+    (tmp_path / "pyproject.toml").write_text("")
+    deep = tmp_path
+    for i in range(_MAX_WALK + 1):
+        deep = deep / f"d{i}"
+    deep.mkdir(parents=True)
+    assert find_pyproject(deep) is None
+
+    # One level shallower should still find it.
+    shallow = tmp_path
+    for i in range(_MAX_WALK):
+        shallow = shallow / f"s{i}"
+    shallow.mkdir(parents=True)
+    assert find_pyproject(shallow) == tmp_path / "pyproject.toml"
+
+
+def test_read_config_full(tmp_path):
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text("[tool.slipcover]\nbranch = true\nsource = \"src\"\nfail-under = 80.0\n")
+    cfg = read_config(toml)
+    assert cfg == {"branch": True, "source": "src", "fail-under": 80.0}
+
+
+def test_read_config_missing_section(tmp_path):
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text("[project]\nname = 'foo'\n")
+    assert read_config(toml) == {}
+
+
+def test_read_config_no_file():
+    assert read_config(None) == {} or True  # auto-discovery may find repo file
+
+
+def test_read_config_all_keys(tmp_path):
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text(
+        "[tool.slipcover]\n"
+        "branch = true\n"
+        "json = true\n"
+        "pretty-print = true\n"
+        "xml = false\n"
+        "xml-package-depth = 3\n"
+        'out = "coverage.json"\n'
+        'source = "src,lib"\n'
+        'omit = "tests/*"\n'
+        "immediate = true\n"
+        "skip-covered = true\n"
+        "fail-under = 90.0\n"
+        "threshold = 75\n"
+        "missing-width = 120\n"
+    )
+    cfg = read_config(toml)
+    assert cfg["branch"] is True
+    assert cfg["json"] is True
+    assert cfg["pretty-print"] is True
+    assert cfg["xml"] is False
+    assert cfg["xml-package-depth"] == 3
+    assert cfg["out"] == "coverage.json"
+    assert cfg["source"] == "src,lib"
+    assert cfg["omit"] == "tests/*"
+    assert cfg["immediate"] is True
+    assert cfg["skip-covered"] is True
+    assert cfg["fail-under"] == 90.0
+    assert cfg["threshold"] == 75
+    assert cfg["missing-width"] == 120
+
+
+def _make_args(**kwargs):
+    defaults = dict(
+        branch=False, json=False, pretty_print=False, xml=False,
+        xml_package_depth=99, out=None, source=None, omit=None,
+        immediate=False, skip_covered=False, fail_under=0,
+        threshold=50, missing_width=80, silent=False, dis=False,
+        debug=False, dont_wrap_pytest=False,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_apply_config_sets_values():
+    args = _make_args()
+    apply_config({"branch": True, "fail-under": 85.5, "source": "src"}, args)
+    assert args.branch is True
+    assert args.fail_under == 85.5
+    assert args.source == "src"
+
+
+def test_apply_config_cli_precedence():
+    args = _make_args(branch=True)
+    apply_config({"branch": False, "fail-under": 90.0}, args, explicit_args={"branch"})
+    assert args.branch is True      # explicit, kept
+    assert args.fail_under == 90.0   # not explicit, applied
+
+
+def test_apply_config_out_becomes_path():
+    args = _make_args()
+    apply_config({"out": "coverage.json"}, args)
+    assert isinstance(args.out, Path)
+    assert str(args.out) == "coverage.json"
+
+
+def test_apply_config_type_error_on_bad_bool():
+    args = _make_args()
+    with pytest.raises(TypeError, match="must be a boolean"):
+        apply_config({"branch": "yes"}, args)
+
+
+def test_apply_config_warns_unknown_key():
+    args = _make_args()
+    with pytest.warns(UserWarning, match="Unknown.*no-such-key"):
+        apply_config({"no-such-key": 42}, args)
+
+
+def test_apply_config_int_coercion():
+    args = _make_args()
+    apply_config({"threshold": 75, "missing-width": 100, "xml-package-depth": 5}, args)
+    assert args.threshold == 75
+    assert args.missing_width == 100
+    assert args.xml_package_depth == 5
+
+
+def test_apply_config_skip_covered_and_pretty_print():
+    args = _make_args()
+    apply_config({"skip-covered": True, "pretty-print": True}, args)
+    assert args.skip_covered is True
+    assert args.pretty_print is True
+
+
+def test_integration_pyproject_applied(tmp_path):
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text("[tool.slipcover]\nbranch = true\nfail-under = 95.0\nsource = \"mypackage\"\n")
+    cfg = read_config(toml)
+    args = _make_args()
+    apply_config(cfg, args)
+    assert args.branch is True
+    assert args.fail_under == 95.0
+    assert args.source == "mypackage"
+
+
+def test_integration_empty_section(tmp_path):
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text("[tool.slipcover]\n")
+    cfg = read_config(toml)
+    args = _make_args()
+    apply_config(cfg, args)
+    assert args.branch is False
+    assert args.fail_under == 0
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,10 +53,15 @@ def test_find_pyproject_finds_file_at_vcs_root(tmp_path):
 
 
 def test_find_pyproject_stops_at_home(tmp_path, monkeypatch):
-    """Should not walk above the user's home directory."""
+    """Should not walk above the user's home directory.
+
+    Patches Path.home() directly rather than the HOME env var: Path.home()
+    resolves via USERPROFILE on Windows, not HOME, so setting HOME alone
+    has no effect there and doesn't control what find_pyproject() sees.
+    """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
     # Place pyproject.toml above the fake home — should NOT be found.
     (tmp_path / "pyproject.toml").write_text("")
     child = fake_home / "projects" / "foo"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,6 +204,19 @@ def test_apply_config_warns_unknown_key():
         apply_config({"no-such-key": 42}, args)
 
 
+@pytest.mark.parametrize("key", ["silent", "dis", "debug", "dont-wrap-pytest"])
+def test_apply_config_rejects_dev_only_flags(key):
+    """silent/dis/debug/dont-wrap-pytest are argparse.SUPPRESS'd,
+    dev-only flags (see __main__.py) -- they shouldn't be part of the
+    stable, user-facing [tool.slipcover] config surface, same as
+    --merge/-m/the script argument/--version/--help are already excluded.
+    """
+    args = _make_args()
+    with pytest.warns(UserWarning, match="Unknown"):
+        apply_config({key: True}, args)
+    assert getattr(args, key.replace("-", "_")) is False  # left at default
+
+
 def test_apply_config_int_coercion():
     args = _make_args()
     apply_config({"threshold": 75, "missing-width": 100, "xml-package-depth": 5}, args)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,6 @@
 import argparse
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,11 +21,12 @@ def test_find_pyproject_walks_up(tmp_path):
 
 
 def test_find_pyproject_returns_none(tmp_path):
+    # _MAX_WALK bounds the search to a few levels under tmp_path, which
+    # sits deep under a system temp dir with no pyproject.toml in any
+    # ancestor -- deterministic without needing an explicit VCS marker.
     child = tmp_path / "nowhere"
     child.mkdir()
-    result = find_pyproject(child)
-    # might find the repo's own file if tmp_path is under the repo tree
-    assert result is None or result.name == "pyproject.toml"
+    assert find_pyproject(child) is None
 
 
 def test_find_pyproject_stops_at_vcs_root(tmp_path):
@@ -94,8 +97,9 @@ def test_read_config_missing_section(tmp_path):
     assert read_config(toml) == {}
 
 
-def test_read_config_no_file():
-    assert read_config(None) == {} or True  # auto-discovery may find repo file
+def test_read_config_no_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert read_config(None) == {}
 
 
 def test_read_config_all_keys(tmp_path):
@@ -172,6 +176,23 @@ def test_apply_config_type_error_on_bad_bool():
         apply_config({"branch": "yes"}, args)
 
 
+def test_apply_config_source_array_is_joined():
+    """TOML's idiomatic way to express multiple values is an array;
+    join it the same way --source's comma-separated CLI form expects,
+    instead of stringifying the Python list representation.
+    """
+    args = _make_args()
+    apply_config({"source": ["src", "lib"]}, args)
+    assert args.source == "src,lib"
+
+
+def test_apply_config_omit_array_is_joined():
+    args = _make_args()
+    apply_config({"omit": ["tests/*", "*.pyc"]}, args)
+    assert args.omit == "tests/*,*.pyc"
+
+
+
 def test_apply_config_warns_unknown_key():
     args = _make_args()
     with pytest.warns(UserWarning, match="Unknown.*no-such-key"):
@@ -212,4 +233,49 @@ def test_integration_empty_section(tmp_path):
     apply_config(cfg, args)
     assert args.branch is False
     assert args.fail_under == 0
+
+
+def test_cli_malformed_toml_clean_error(tmp_path, monkeypatch):
+    """A broken pyproject.toml must produce a clean, informative CLI error
+    (matching black/ruff/mypy/pytest convention) -- not an unhandled
+    Python traceback.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[tool.slipcover\nbranch = true\n")
+    (tmp_path / "script.py").write_text("x = 1\n")
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode != 0
+    assert 'Traceback' not in p.stderr
+    assert 'pyproject.toml' in p.stderr
+
+
+def test_cli_bad_config_value_clean_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = "not-a-number"\n')
+    (tmp_path / "script.py").write_text("x = 1\n")
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode != 0
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_valid_pyproject_config_applied(tmp_path, monkeypatch):
+    """Sanity check that a real subprocess run actually reads and applies
+    pyproject.toml config end-to-end (no test currently exercises this).
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 100.0\n')
+    # foo()'s body is never called, so coverage is 50%, below the threshold
+    (tmp_path / "script.py").write_text("def foo():\n    pass\n")
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2  # fail-under from pyproject.toml kicks in
+    assert 'Traceback' not in p.stderr
 


### PR DESCRIPTION
Closes: https://github.com/plasma-umass/slipcover/issues/82

This PR adds support for finding a pyproject.toml on the directory tree and reads [tool.slipcover] from it, configuring slipcover accordingly. CLI arguments will always win over this configuration, and will always take precedence.

Example:
```
[tool.slipcover]
branch = true
source = "src"
omit = "tests/*"
fail-under = 80.0
json = true
out = "coverage.json"
skip-covered = true
```

This opens the possibility to support .rc files too.

In addition to the tests added, I tested this branch in other project.

Disclaimer, this PR was made with the assistance of AI.