### PR TITLE
feat: xdist retroactive instrumentation, exclude_lines, and omit propagation

### DIFF
--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -180,6 +180,8 @@ def main():
     ap.add_argument('--threshold', type=int, default=50, metavar="T",
                     help="threshold for de-instrumentation (if not immediate)")
     ap.add_argument('--missing-width', type=int, default=80, metavar="WIDTH", help="maximum width for `missing' column")
+    ap.add_argument('--exclude-lines', action='append', metavar="REGEX",
+                    help="regex pattern for source lines to exclude from coverage (may be repeated)")
 
     # intended for slipcover development only
     ap.add_argument('--silent', action='store_true', help=argparse.SUPPRESS)
@@ -229,7 +231,8 @@ def main():
     omit_list = args.omit.split(',') if args.omit else None
     sci = sc.Slipcover(immediate=args.immediate,
                        d_miss_threshold=args.threshold, branch=args.branch,
-                       disassemble=args.dis, source=args.source, omit=omit_list)
+                       disassemble=args.dis, source=args.source, omit=omit_list,
+                       exclude_lines=args.exclude_lines)
 
 
     if not args.dont_wrap_pytest:
@@ -247,6 +250,8 @@ def main():
             os.environ["SLIPCOVER_SOURCE"] = source_str
         if args.omit:
             os.environ["SLIPCOVER_OMIT"] = args.omit
+        if args.exclude_lines:
+            os.environ["SLIPCOVER_EXCLUDE_LINES"] = "\n".join(args.exclude_lines)
 
     if platform.system() != 'Windows':
         os.fork = fork_shim(sci)
@@ -309,10 +314,10 @@ def main():
             runpy.run_module(*args.module, run_name='__main__', alter_sys=True)
 
     if args.fail_under:
-        cov = sci.get_coverage()
+        cov = get_coverage(sci)
         if cov['summary']['percent_covered'] < args.fail_under:
             return 2
-    
+
     return 0
 
 

--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -280,45 +280,51 @@ def main():
 
     atexit.register(sci_atexit)
 
-    if args.script:
-        # python 'globals' for the script being executed
-        script_globals: Dict[Any, Any] = dict()
+    exit_code = 0
 
-        # needed so that the script being invoked behaves like the main one
-        script_globals['__name__'] = '__main__'
-        script_globals['__file__'] = args.script
+    try:
+        if args.script:
+            # python 'globals' for the script being executed
+            script_globals: Dict[Any, Any] = dict()
 
-        sys.argv = [str(args.script), *args.script_or_module_args]
+            # needed so that the script being invoked behaves like the main one
+            script_globals['__name__'] = '__main__'
+            script_globals['__file__'] = args.script
 
-        # the 1st item in sys.path is always the main script's directory
-        sys.path.pop(0)
-        sys.path.insert(0, str(base_path))
+            sys.argv = [str(args.script), *args.script_or_module_args]
 
-        with open(args.script, "r") as f:
-            t = ast.parse(f.read())
-            if args.branch and file_matcher.matches(args.script):
-                t = br.preinstrument(t)
-            code = compile(t, str(Path(args.script).resolve()), "exec")
+            # the 1st item in sys.path is always the main script's directory
+            sys.path.pop(0)
+            sys.path.insert(0, str(base_path))
+
+            with open(args.script, "r") as f:
+                t = ast.parse(f.read())
+                if args.branch and file_matcher.matches(args.script):
+                    t = br.preinstrument(t)
+                code = compile(t, str(Path(args.script).resolve()), "exec")
 
 
-        if file_matcher.matches(args.script):
-            code = sci.instrument(code)
+            if file_matcher.matches(args.script):
+                code = sci.instrument(code)
 
-        with sc.ImportManager(sci, file_matcher):
-            exec(code, script_globals)
+            with sc.ImportManager(sci, file_matcher):
+                exec(code, script_globals)
 
-    else:
-        import runpy
-        sys.argv = [*args.module, *args.script_or_module_args]
-        with sc.ImportManager(sci, file_matcher):
-            runpy.run_module(*args.module, run_name='__main__', alter_sys=True)
+        else:
+            import runpy
+            sys.argv = [*args.module, *args.script_or_module_args]
+            with sc.ImportManager(sci, file_matcher):
+                runpy.run_module(*args.module, run_name='__main__', alter_sys=True)
+
+    except SystemExit as e:
+        exit_code = e.code if isinstance(e.code, int) else (1 if e.code else 0)
 
     if args.fail_under:
         cov = get_coverage(sci)
         if cov['summary']['percent_covered'] < args.fail_under:
             return 2
 
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -278,53 +278,52 @@ def main():
             else:
                 printit(coverage, sys.stdout)
 
+            if args.fail_under and coverage['summary']['percent_covered'] < args.fail_under:
+                sys.stdout.flush()
+                sys.stderr.flush()
+                os._exit(2)
+
     atexit.register(sci_atexit)
 
-    exit_code = 0
+    if args.script:
+        # python 'globals' for the script being executed
+        script_globals: Dict[Any, Any] = dict()
 
-    try:
-        if args.script:
-            # python 'globals' for the script being executed
-            script_globals: Dict[Any, Any] = dict()
+        # needed so that the script being invoked behaves like the main one
+        script_globals['__name__'] = '__main__'
+        script_globals['__file__'] = args.script
 
-            # needed so that the script being invoked behaves like the main one
-            script_globals['__name__'] = '__main__'
-            script_globals['__file__'] = args.script
+        sys.argv = [str(args.script), *args.script_or_module_args]
 
-            sys.argv = [str(args.script), *args.script_or_module_args]
+        # the 1st item in sys.path is always the main script's directory
+        sys.path.pop(0)
+        sys.path.insert(0, str(base_path))
 
-            # the 1st item in sys.path is always the main script's directory
-            sys.path.pop(0)
-            sys.path.insert(0, str(base_path))
-
-            with open(args.script, "r") as f:
-                t = ast.parse(f.read())
-                if args.branch and file_matcher.matches(args.script):
-                    t = br.preinstrument(t)
-                code = compile(t, str(Path(args.script).resolve()), "exec")
+        with open(args.script, "r") as f:
+            t = ast.parse(f.read())
+            if args.branch and file_matcher.matches(args.script):
+                t = br.preinstrument(t)
+            code = compile(t, str(Path(args.script).resolve()), "exec")
 
 
-            if file_matcher.matches(args.script):
-                code = sci.instrument(code)
+        if file_matcher.matches(args.script):
+            code = sci.instrument(code)
 
-            with sc.ImportManager(sci, file_matcher):
-                exec(code, script_globals)
+        with sc.ImportManager(sci, file_matcher):
+            exec(code, script_globals)
 
-        else:
-            import runpy
-            sys.argv = [*args.module, *args.script_or_module_args]
-            with sc.ImportManager(sci, file_matcher):
-                runpy.run_module(*args.module, run_name='__main__', alter_sys=True)
-
-    except SystemExit as e:
-        exit_code = e.code if isinstance(e.code, int) else (1 if e.code else 0)
+    else:
+        import runpy
+        sys.argv = [*args.module, *args.script_or_module_args]
+        with sc.ImportManager(sci, file_matcher):
+            runpy.run_module(*args.module, run_name='__main__', alter_sys=True)
 
     if args.fail_under:
         cov = get_coverage(sci)
         if cov['summary']['percent_covered'] < args.fail_under:
             return 2
 
-    return exit_code
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/slipcover/pytest_plugin.py
+++ b/src/slipcover/pytest_plugin.py
@@ -71,6 +71,8 @@ def pytest_configure(config):
     branch = os.environ.get("SLIPCOVER_BRANCH") == "1"
     source = os.environ.get("SLIPCOVER_SOURCE")
     omit = os.environ.get("SLIPCOVER_OMIT")
+    exclude_lines_str = os.environ.get("SLIPCOVER_EXCLUDE_LINES")
+    exclude_lines = exclude_lines_str.split("\n") if exclude_lines_str else None
 
     # Set up file matcher
     _file_matcher = sc.FileMatcher()
@@ -85,9 +87,13 @@ def pytest_configure(config):
             if o:
                 _file_matcher.addOmit(o)
 
-    # Create Slipcover instance
-    source_list = [s.strip() for s in source.split(",")] if source else None
-    _slipcover_instance = sc.Slipcover(branch=branch, source=source_list)
+    # Create Slipcover instance — workers don't pass source to avoid
+    # _add_unseen_source_files adding files with AST-parsed line counts
+    # that differ from bytecode-parsed counts.  The main process (via
+    # __main__.py) handles unseen-file scanning instead.
+    omit_list = [o.strip() for o in omit.split(",") if o.strip()] if omit else None
+    _slipcover_instance = sc.Slipcover(branch=branch, omit=omit_list,
+                                       exclude_lines=exclude_lines)
 
     # Wrap pytest's assertion rewriter for instrumentation
     sc.wrap_pytest(_slipcover_instance, _file_matcher)
@@ -95,6 +101,109 @@ def pytest_configure(config):
     # Start import instrumentation
     _import_manager = sc.ImportManager(_slipcover_instance, _file_matcher)
     _import_manager.__enter__()
+
+    # Retroactively instrument modules already in sys.modules (inherited
+    # from the main process via execnet fork).  Without this, those modules
+    # bypass the ImportManager and their coverage is never recorded.
+    #
+    # On Python 3.12+, sys.monitoring.set_local_events must be called on
+    # the actual live code objects, not freshly compiled ones.  We find
+    # all function/method objects in each module and instrument their
+    # __code__ attributes directly.
+    import ast
+    import sys as _sys
+    import types
+
+    def _instrument_func(func):
+        if isinstance(func, types.FunctionType) and _file_matcher.matches(func.__code__.co_filename):
+            _slipcover_instance.instrument(func.__code__)
+
+    visited: set = set()
+    for mod in list(_sys.modules.values()):
+        if not hasattr(mod, '__file__'):
+            continue
+        origin = getattr(mod, '__file__', None)
+        if origin and _file_matcher.matches(origin):
+            _slipcover_instance.register_module(mod)
+
+            # Populate code_lines with ALL source lines (module-level +
+            # function bodies) so the merge with the main process works
+            # correctly.  The main process has module-level executed_lines
+            # from import; workers supply function body executed_lines.
+            abs_origin = str(Path(origin).resolve())
+            if abs_origin not in _slipcover_instance.code_lines:
+                try:
+                    source_text = Path(origin).read_text()
+                    code = compile(ast.parse(source_text), abs_origin, "exec")
+                    _slipcover_instance.code_lines[abs_origin].update(
+                        sc.Slipcover.lines_from_code(code)
+                    )
+                except Exception:
+                    pass
+
+            for func in sc.Slipcover.find_functions(mod.__dict__.values(), visited):
+                _instrument_func(func)
+            # Scan instance attributes of module-level objects for hidden
+            # function references (e.g., Hatchet task wrappers store the
+            # original function in obj._task.fn).
+            _deep_scan_visited: set = set()
+            for val in mod.__dict__.values():
+                _deep_scan_functions(val, _instrument_func, _deep_scan_visited, _file_matcher, depth=3)
+            # Scan containers (dicts, lists) in module and class dicts for
+            # lambdas (e.g., column_formatters = {"key": lambda ...}).
+            _scan_containers_for_functions(mod, _instrument_func, _file_matcher)
+
+
+def _instrument_container_functions(container, instrument_fn, visited):
+    """Instrument functions found in a dict/list/tuple/set, recursing into nested containers."""
+    import types
+
+    items = container.values() if isinstance(container, dict) else container
+    for val in items:
+        if isinstance(val, types.FunctionType):
+            if id(val) not in visited:
+                visited.add(id(val))
+                instrument_fn(val)
+        elif isinstance(val, (dict, list, tuple)):
+            _instrument_container_functions(val, instrument_fn, visited)
+
+
+def _scan_containers_for_functions(mod, instrument_fn, file_matcher):
+    """Find functions stored in containers at module and class level."""
+    visited: set = set()
+    for val in mod.__dict__.values():
+        # Module-level containers (dicts, lists)
+        if isinstance(val, (dict, list, tuple)):
+            _instrument_container_functions(val, instrument_fn, visited)
+        # Class-level containers
+        elif isinstance(val, type):
+            for cls_val in val.__dict__.values():
+                if isinstance(cls_val, (dict, list, tuple)):
+                    _instrument_container_functions(cls_val, instrument_fn, visited)
+
+
+def _deep_scan_functions(obj, instrument_fn, visited, file_matcher, depth):
+    """Recursively scan object attributes for hidden function references."""
+    if depth <= 0 or id(obj) in visited:
+        return
+    visited.add(id(obj))
+
+    import types
+
+    # Skip basic types, modules, and types themselves
+    if isinstance(obj, (str, bytes, int, float, bool, type(None), type, types.ModuleType)):
+        return
+
+    try:
+        obj_vars = vars(obj)
+    except TypeError:
+        return
+
+    for val in obj_vars.values():
+        if isinstance(val, types.FunctionType):
+            instrument_fn(val)
+        elif not isinstance(val, (str, bytes, int, float, bool, type(None), list, dict, set, tuple)):
+            _deep_scan_functions(val, instrument_fn, visited, file_matcher, depth - 1)
 
 
 def pytest_unconfigure(config):

--- a/src/slipcover/slipcover.py
+++ b/src/slipcover/slipcover.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dis
+import re
 import sys
 import threading
 import types
@@ -304,13 +305,15 @@ class Slipcover:
     def __init__(self, immediate: bool = False,
                  d_miss_threshold: int = 50, branch: bool = False,
                  disassemble: bool = False, source: Optional[List[str]] = None,
-                 omit: Optional[List[str]] = None):
+                 omit: Optional[List[str]] = None,
+                 exclude_lines: Optional[List[str]] = None):
         self.immediate = immediate
         self.d_miss_threshold = d_miss_threshold
         self.branch = branch
         self.disassemble = disassemble
         self.source = source
         self.omit = omit
+        self.exclude_lines = [re.compile(p) for p in exclude_lines] if exclude_lines else None
 
         # mutex protecting this state
         self.lock = threading.RLock()
@@ -657,6 +660,148 @@ class Slipcover:
             self.all_seen.clear()
 
 
+    @staticmethod
+    def _exclude_def_signature_lines(files: dict) -> None:
+        """Exclude continuation lines of multi-line function/class signatures.
+
+        In Python < 3.14, parameter type annotations are evaluated eagerly
+        and generate bytecodes at module level.  Lines that only hold
+        parameter declarations (between ``def foo(`` and the body) are not
+        meaningful executable statements.  coverage.py silently drops them;
+        we do the same so the two tools agree.
+        """
+        import ast
+
+        _ast_cache: dict = {}
+
+        def _get_tree(path: str):
+            if path not in _ast_cache:
+                try:
+                    p = Path(path)
+                    if not p.is_absolute():
+                        p = Path.cwd() / p
+                    _ast_cache[path] = ast.parse(p.read_text())
+                except Exception:
+                    _ast_cache[path] = None
+            return _ast_cache[path]
+
+        for fname, fdata in files.items():
+            tree = _get_tree(fname)
+            if tree is None:
+                continue
+
+            sig_lines: set = set()
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    def_line = node.lineno
+                    if node.body:
+                        body_start = node.body[0].lineno
+                        # Decorators precede node.lineno, so def_line+1
+                        # through body_start-1 are signature continuation lines
+                        for ln in range(def_line + 1, body_start):
+                            sig_lines.add(ln)
+
+            if sig_lines:
+                fdata['executed_lines'] = [l for l in fdata['executed_lines'] if l not in sig_lines]
+                fdata['missing_lines'] = [l for l in fdata['missing_lines'] if l not in sig_lines]
+
+    def _filter_excluded_lines(self, files: dict) -> None:
+        """Remove lines matching exclude_lines patterns from coverage data.
+
+        Like coverage.py, when an excluded line is a control structure (if,
+        for, while, with, try, class, def, etc.), the entire indented body
+        is also excluded.
+        """
+        file_cache: dict = {}
+
+        def read_source(path: str) -> List[str]:
+            if path not in file_cache:
+                try:
+                    p = Path(path)
+                    if not p.is_absolute():
+                        p = Path.cwd() / p
+                    with open(p) as f:
+                        file_cache[path] = f.readlines()
+                except OSError:
+                    file_cache[path] = []
+            return file_cache[path]
+
+        # Keywords that start a block whose body should be excluded
+        _BLOCK_KW = re.compile(r'^\s*(if|elif|else|for|while|with|try|except|finally|class|def|case|match|async\s+def|async\s+for|async\s+with)\b')
+
+        def _indent(line: str) -> int:
+            return len(line) - len(line.lstrip())
+
+        def _exclude_block_body(source_lines, start_idx, base_indent, excluded):
+            """Exclude all lines indented deeper than base_indent."""
+            total = len(source_lines)
+            i = start_idx
+            while i < total:
+                body_line = source_lines[i]
+                stripped = body_line.strip()
+                if stripped == '' or stripped.startswith('#'):
+                    excluded.add(i + 1)
+                    i += 1
+                    continue
+                if _indent(body_line) > base_indent:
+                    excluded.add(i + 1)
+                    i += 1
+                else:
+                    break
+            return i
+
+        def _get_excluded_set(source_lines: List[str]) -> set:
+            excluded = set()
+            total = len(source_lines)
+            i = 0
+            while i < total:
+                line = source_lines[i]
+                lineno = i + 1
+                if any(rx.search(line) for rx in self.exclude_lines):
+                    excluded.add(lineno)
+                    stripped = line.strip()
+
+                    if stripped.startswith('@'):
+                        # Decorator match: skip forward past more decorators
+                        # to the def/class, then exclude it and its body
+                        base_indent = _indent(line)
+                        i += 1
+                        while i < total:
+                            nxt = source_lines[i]
+                            nxt_stripped = nxt.strip()
+                            if nxt_stripped == '' or nxt_stripped.startswith('#'):
+                                excluded.add(i + 1)
+                                i += 1
+                                continue
+                            if nxt_stripped.startswith('@'):
+                                excluded.add(i + 1)
+                                i += 1
+                                continue
+                            # Should be the def/class line
+                            if _BLOCK_KW.search(nxt):
+                                excluded.add(i + 1)
+                                i = _exclude_block_body(source_lines, i + 1, base_indent, excluded)
+                            break
+                        continue
+
+                    if _BLOCK_KW.search(line):
+                        base_indent = _indent(line)
+                        i = _exclude_block_body(source_lines, i + 1, base_indent, excluded)
+                        continue
+                i += 1
+            return excluded
+
+        for fname, fdata in files.items():
+            source_lines = read_source(fname)
+            if not source_lines:
+                continue
+
+            excluded = _get_excluded_set(source_lines)
+
+            if excluded:
+                fdata['executed_lines'] = [l for l in fdata['executed_lines'] if l not in excluded]
+                fdata['missing_lines'] = [l for l in fdata['missing_lines'] if l not in excluded]
+
     def get_coverage(self):
         """Returns coverage information collected."""
 
@@ -691,6 +836,11 @@ class Slipcover:
                     f_files['missing_branches'] = sorted(self.code_branches[f] - branches_seen)
 
                 files[simp.simplify(f)] = f_files
+
+            self._exclude_def_signature_lines(files)
+
+            if self.exclude_lines:
+                self._filter_excluded_lines(files)
 
             cov = {
                 'meta': Slipcover._make_meta(self.branch),
@@ -746,6 +896,15 @@ class Slipcover:
                 if root.__func__ not in visited:
                     visited.add(root.__func__)
                     yield root.__func__
+
+            elif issubclass(type(root), property):
+                for accessor in (root.fget, root.fset, root.fdel):
+                    if accessor is not None:
+                        yield from find_funcs(accessor)
+
+            # Follow __wrapped__ for decorated functions (functools.wraps, etc.)
+            if hasattr(root, '__wrapped__') and root.__wrapped__ is not root:
+                yield from find_funcs(root.__wrapped__)
 
         # FIXME this may yield "dictionary changed size during iteration"
         return [f for it in items for f in find_funcs(it)]

--- a/tests/test_exclude_lines.py
+++ b/tests/test_exclude_lines.py
@@ -1,0 +1,300 @@
+"""Tests for --exclude-lines and def-signature exclusion features."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+import slipcover.slipcover as sc
+
+PYTHON_VERSION = sys.version_info[0:2]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _filter_excluded_lines
+# ---------------------------------------------------------------------------
+
+
+def _make_coverage_with_source(tmp_path, source, executed, missing):
+    """Create a source file and a coverage dict referencing it."""
+    f = tmp_path / "mod.py"
+    f.write_text(dedent(source))
+    fname = str(f)
+    files = {
+        fname: {
+            "executed_lines": executed,
+            "missing_lines": missing,
+        }
+    }
+    return files, fname
+
+
+def test_exclude_lines_single_line(tmp_path):
+    """Lines matching an exclude pattern are removed from both executed and missing."""
+    source = """\
+        x = 1
+        if TYPE_CHECKING:
+            import os
+        y = 2
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 4],
+        missing=[2, 3],
+    )
+    sci = sc.Slipcover(exclude_lines=["if TYPE_CHECKING:"])
+    sci._filter_excluded_lines(files)
+
+    assert 2 not in files[fname]["missing_lines"]
+    assert 2 not in files[fname]["executed_lines"]
+
+
+def test_exclude_lines_block_body(tmp_path):
+    """When an excluded line is a block statement, its indented body is also excluded."""
+    source = """\
+        x = 1
+        if TYPE_CHECKING:
+            import os
+            import sys
+        y = 2
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 5],
+        missing=[2, 3, 4],
+    )
+    sci = sc.Slipcover(exclude_lines=["if TYPE_CHECKING:"])
+    sci._filter_excluded_lines(files)
+
+    assert files[fname]["missing_lines"] == []
+
+
+def test_exclude_lines_decorator_cascade(tmp_path):
+    """When an excluded line is a decorator, the decorated function body is excluded."""
+    source = """\
+        from abc import abstractmethod
+
+        class Base:
+            @abstractmethod
+            def method(self):
+                pass
+
+            def concrete(self):
+                return 1
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 3, 8, 9],
+        missing=[4, 5, 6],
+    )
+    sci = sc.Slipcover(exclude_lines=[r"@(abc\.)?abstractmethod"])
+    sci._filter_excluded_lines(files)
+
+    # decorator, def, and body should all be excluded
+    assert 4 not in files[fname]["missing_lines"]
+    assert 5 not in files[fname]["missing_lines"]
+    assert 6 not in files[fname]["missing_lines"]
+
+
+def test_exclude_lines_stacked_decorators(tmp_path):
+    """Stacked decorators before the excluded one are not affected, body is excluded."""
+    source = """\
+        class Base:
+            @property
+            @abstractmethod
+            def name(self):
+                pass
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1],
+        missing=[2, 3, 4, 5],
+    )
+    sci = sc.Slipcover(exclude_lines=[r"@(abc\.)?abstractmethod"])
+    sci._filter_excluded_lines(files)
+
+    # @abstractmethod line and everything after it (def + body) should be excluded
+    assert 3 not in files[fname]["missing_lines"]
+    assert 4 not in files[fname]["missing_lines"]
+    assert 5 not in files[fname]["missing_lines"]
+    # @property is NOT excluded (it's before the matching decorator)
+    assert 2 in files[fname]["missing_lines"]
+
+
+def test_exclude_lines_case_block(tmp_path):
+    """case/match statements are recognized as block keywords."""
+    source = """\
+        match x:
+            case 1:
+                print("one")
+            case _:  # pragma: no cover
+                assert_never(x)
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 2, 3],
+        missing=[4, 5],
+    )
+    sci = sc.Slipcover(exclude_lines=["pragma: no cover"])
+    sci._filter_excluded_lines(files)
+
+    assert 4 not in files[fname]["missing_lines"]
+    assert 5 not in files[fname]["missing_lines"]
+
+
+def test_exclude_lines_pragma_no_cover(tmp_path):
+    """The classic pragma: no cover pattern works."""
+    source = """\
+        def foo():
+            if debug:  # pragma: no cover
+                log()
+            return 1
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 4],
+        missing=[2, 3],
+    )
+    sci = sc.Slipcover(exclude_lines=["pragma: no cover"])
+    sci._filter_excluded_lines(files)
+
+    assert files[fname]["missing_lines"] == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _exclude_def_signature_lines
+# ---------------------------------------------------------------------------
+
+
+def test_signature_lines_excluded(tmp_path):
+    """Multi-line function signature continuation lines are excluded."""
+    source = """\
+        def foo(
+            x: int,
+            y: str,
+        ) -> bool:
+            return True
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 5],
+        missing=[2, 3, 4],
+    )
+    sc.Slipcover._exclude_def_signature_lines(files)
+
+    # Lines 2-4 (parameters + return type) should be excluded
+    assert files[fname]["missing_lines"] == []
+
+
+def test_signature_lines_async_def(tmp_path):
+    """Async function signature continuation lines are excluded."""
+    source = """\
+        async def handler(
+            request: Request,
+            db: Session,
+        ) -> Response:
+            return Response()
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 5],
+        missing=[2, 3, 4],
+    )
+    sc.Slipcover._exclude_def_signature_lines(files)
+
+    assert files[fname]["missing_lines"] == []
+
+
+def test_signature_lines_class_bases(tmp_path):
+    """Multi-line class base list continuation lines are excluded."""
+    source = """\
+        class MyView(
+            BaseAdmin,
+            SomeMixin,
+        ):
+            pass
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1, 5],
+        missing=[2, 3, 4],
+    )
+    sc.Slipcover._exclude_def_signature_lines(files)
+
+    assert files[fname]["missing_lines"] == []
+
+
+def test_single_line_def_unaffected(tmp_path):
+    """Single-line function defs are not affected by signature exclusion."""
+    source = """\
+        def foo(x: int) -> bool:
+            return True
+    """
+    files, fname = _make_coverage_with_source(
+        tmp_path, source,
+        executed=[1],
+        missing=[2],
+    )
+    sc.Slipcover._exclude_def_signature_lines(files)
+
+    # Body line should remain as missing
+    assert files[fname]["missing_lines"] == [2]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration test: --exclude-lines flag
+# ---------------------------------------------------------------------------
+
+
+def test_exclude_lines_cli(tmp_path):
+    """--exclude-lines flag is passed through CLI and filters coverage."""
+    mod = tmp_path / "mod.py"
+    mod.write_text(dedent("""\
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            import os
+
+        def foo():
+            return 1
+    """))
+
+    test = tmp_path / "test_mod.py"
+    test.write_text(dedent("""\
+        import sys
+        sys.path.insert(0, '.')
+        from mod import foo
+
+        def test_foo():
+            assert foo() == 1
+    """))
+
+    out = tmp_path / "cov.json"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "slipcover",
+            "--source", str(tmp_path),
+            "--exclude-lines", "if TYPE_CHECKING:",
+            "--json", "--out", str(out),
+            "-m", "pytest", "-q", str(test),
+        ],
+        capture_output=True, text=True, cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    with out.open() as f:
+        cov = json.load(f)
+
+    keys = [k for k in cov["files"] if "mod.py" in k]
+    assert keys
+    file_cov = cov["files"][keys[0]]
+
+    # TYPE_CHECKING body (line 4) should be excluded from both missing and executed.
+    # Line 3 (the `if` itself) is executed at runtime (condition evaluates to False)
+    # but should not appear as missing.
+    assert 3 not in file_cov["missing_lines"]
+    assert 4 not in file_cov["missing_lines"]
+    assert 4 not in file_cov["executed_lines"]

--- a/tests/test_xdist_continuation_lines.py
+++ b/tests/test_xdist_continuation_lines.py
@@ -1,0 +1,248 @@
+"""xfail tests for expression continuation lines not tracked in xdist workers.
+
+On Python 3.12+, when modules are pre-imported by the main process (e.g. via
+conftest.py) and inherited by xdist workers via fork, the retroactive
+instrumentation uses ``find_functions()`` to discover function objects.
+However, ``find_functions()`` does not recurse into container attributes
+(dicts, lists) — so lambda/function references stored in class-level dicts
+like ``column_formatters = {"key": lambda ...}`` are never instrumented.
+
+Each test creates a minimal reproduction with a conftest.py that pre-imports
+the target module, then runs slipcover with -n 2 and verifies coverage.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("xdist")
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform == "win32", reason="xdist tests are Unix-specific"),
+    pytest.mark.skipif(sys.version_info < (3, 12), reason="sys.monitoring requires 3.12+"),
+]
+
+
+def _run_slipcover_xdist(tmp_path, module_code, test_code, conftest_code, workers=2):
+    """Write module + conftest + test, run slipcover with xdist, return file coverage."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    module_file = src_dir / "target.py"
+    module_file.write_text(module_code)
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+
+    conftest = tests_dir / "conftest.py"
+    conftest.write_text(conftest_code)
+
+    test_file = tests_dir / "test_target.py"
+    test_file.write_text(test_code)
+
+    out = tmp_path / "cov.json"
+    env = {**os.environ, "PYTHONPATH": str(src_dir)}
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "slipcover",
+            "--source", str(src_dir),
+            "--json", "--out", str(out),
+            "-m", "pytest", "-n", str(workers), "-q",
+            str(tests_dir),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+    )
+
+    assert result.returncode == 0, (
+        f"slipcover failed (rc={result.returncode}):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    with out.open() as f:
+        cov = json.load(f)
+
+    keys = [k for k in cov["files"] if "target.py" in k]
+    assert keys, f"target.py not in coverage files: {list(cov['files'])}"
+    return cov["files"][keys[0]]
+
+
+# Conftest that forces module import in main process before xdist forks
+_CONFTEST = '''\
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+import target  # noqa: F401 — pre-import so workers inherit it via fork
+'''
+
+
+# ---------------------------------------------------------------------------
+# Test 1: lambda stored in class-level dict (e.g. column_formatters)
+# ---------------------------------------------------------------------------
+
+def test_lambda_in_class_dict(tmp_path, monkeypatch):
+    """Lambdas stored in class-level dict attributes should be instrumented."""
+    monkeypatch.chdir(tmp_path)
+
+    module = '''\
+class View:
+    formatters = {
+        "name": lambda obj: (
+            obj.upper()
+            if obj
+            else "-"
+        ),
+    }
+'''
+    test = '''\
+from target import View
+
+def test_with_value():
+    assert View.formatters["name"]("hello") == "HELLO"
+
+def test_without_value():
+    assert View.formatters["name"]("") == "-"
+'''
+    file_cov = _run_slipcover_xdist(tmp_path, module, test, _CONFTEST)
+
+    assert file_cov["missing_lines"] == [], (
+        f"All lines should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: lambda in class dict with multi-line f-string
+# ---------------------------------------------------------------------------
+
+def test_lambda_fstring_in_class_dict(tmp_path, monkeypatch):
+    """Lambda with f-string stored in class dict should have all lines covered."""
+    monkeypatch.chdir(tmp_path)
+
+    module = '''\
+class Admin:
+    formatters = {
+        "link": lambda item: (
+            f"<a>{item}</a>"
+        ),
+    }
+'''
+    test = '''\
+from target import Admin
+
+def test_format_link():
+    assert Admin.formatters["link"]("x") == "<a>x</a>"
+'''
+    file_cov = _run_slipcover_xdist(tmp_path, module, test, _CONFTEST)
+
+    assert file_cov["missing_lines"] == [], (
+        f"All lines should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: lambda in nested dict (dict inside dict)
+# ---------------------------------------------------------------------------
+
+def test_lambda_in_nested_dict(tmp_path, monkeypatch):
+    """Lambdas stored in nested dict structures should be instrumented."""
+    monkeypatch.chdir(tmp_path)
+
+    module = '''\
+registry = {
+    "formatters": {
+        "upper": lambda x: (
+            x.upper()
+            if x
+            else ""
+        ),
+    },
+}
+'''
+    test = '''\
+from target import registry
+
+def test_upper():
+    assert registry["formatters"]["upper"]("hello") == "HELLO"
+
+def test_empty():
+    assert registry["formatters"]["upper"]("") == ""
+'''
+    file_cov = _run_slipcover_xdist(tmp_path, module, test, _CONFTEST)
+
+    assert file_cov["missing_lines"] == [], (
+        f"All lines should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: lambda in list (e.g. validators list)
+# ---------------------------------------------------------------------------
+
+def test_lambda_in_list(tmp_path, monkeypatch):
+    """Lambdas stored in module-level lists should be instrumented."""
+    monkeypatch.chdir(tmp_path)
+
+    module = '''\
+validators = [
+    lambda x: (
+        "ok"
+        if x > 0
+        else "bad"
+    ),
+]
+'''
+    test = '''\
+from target import validators
+
+def test_positive():
+    assert validators[0](1) == "ok"
+
+def test_negative():
+    assert validators[0](-1) == "bad"
+'''
+    file_cov = _run_slipcover_xdist(tmp_path, module, test, _CONFTEST)
+
+    assert file_cov["missing_lines"] == [], (
+        f"All lines should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: multi-line call args inside class method stored in dict
+# ---------------------------------------------------------------------------
+
+def test_call_args_in_class_dict_lambda(tmp_path, monkeypatch):
+    """Call-arg continuation lines in dict-stored lambdas should be covered."""
+    monkeypatch.chdir(tmp_path)
+
+    module = '''\
+class Config:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+class View:
+    builders = {
+        "cfg": lambda: Config(
+            a="hello",
+            b="world",
+        ),
+    }
+'''
+    test = '''\
+from target import View
+
+def test_builder():
+    c = View.builders["cfg"]()
+    assert c.a == "hello"
+    assert c.b == "world"
+'''
+    file_cov = _run_slipcover_xdist(tmp_path, module, test, _CONFTEST)
+
+    assert file_cov["missing_lines"] == [], (
+        f"All lines should be covered; missing: {file_cov['missing_lines']}"
+    )

--- a/tests/test_xdist_fixes.py
+++ b/tests/test_xdist_fixes.py
@@ -1,0 +1,360 @@
+"""Tests for xdist-specific fixes: omit propagation, fail_under, retroactive instrumentation."""
+
+import json
+import os
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("xdist")
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform == "win32", reason="xdist tests are Unix-specific"),
+    pytest.mark.skipif(sys.version_info < (3, 12), reason="retroactive instrumentation requires 3.12+"),
+]
+
+
+def _run_slipcover(args, *, cwd, env=None):
+    """Run slipcover as subprocess, return (returncode, stdout, stderr)."""
+    full_env = {**os.environ, **(env or {})}
+    result = subprocess.run(
+        [sys.executable, "-m", "slipcover", *args],
+        capture_output=True, text=True, cwd=str(cwd), env=full_env,
+    )
+    return result
+
+
+def _setup_project(tmp_path, module_code, test_code, conftest_code=""):
+    """Create src/target.py + tests/test_target.py + optional tests/conftest.py."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "target.py").write_text(dedent(module_code))
+
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_target.py").write_text(dedent(test_code))
+    if conftest_code:
+        (tests / "conftest.py").write_text(dedent(conftest_code))
+
+    return src, tests
+
+
+def _get_file_cov(cov_path, filename="target.py"):
+    """Load JSON coverage and return file coverage for the given filename."""
+    with open(cov_path) as f:
+        cov = json.load(f)
+    keys = [k for k in cov["files"] if filename in k]
+    assert keys, f"{filename} not in {list(cov['files'])}"
+    return cov["files"][keys[0]], cov
+
+
+_CONFTEST_PREIMPORT = '''\
+    import sys, pathlib
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+    import target  # noqa: F401
+'''
+
+
+# ---------------------------------------------------------------------------
+# Test: --omit propagated to xdist workers
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_omit_propagation(tmp_path):
+    """Files matching --omit should not appear in coverage even with xdist."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "included.py").write_text("def inc(): return 1\n")
+    (src / "excluded.py").write_text("def exc(): return 2\n")
+
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_it.py").write_text(dedent("""\
+        import sys
+        sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent / "src"))
+        from included import inc
+
+        def test_inc():
+            assert inc() == 1
+    """))
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src), "--omit", str(src / "excluded.py"),
+         "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    with open(out) as f:
+        cov = json.load(f)
+
+    filenames = list(cov["files"].keys())
+    assert not any("excluded.py" in f for f in filenames), (
+        f"excluded.py should be omitted, found: {filenames}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: --fail-under uses merged xdist coverage
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_fail_under_uses_merged_coverage(tmp_path):
+    """--fail-under should use merged coverage from all workers, not just main process."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            def branch_a():
+                return "a"
+
+            def branch_b():
+                return "b"
+        """,
+        test_code="""\
+            import sys
+            sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent / "src"))
+            from target import branch_a, branch_b
+
+            def test_a():
+                assert branch_a() == "a"
+
+            def test_b():
+                assert branch_b() == "b"
+        """,
+    )
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src), "--fail-under", "100",
+         "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+
+    # Should pass: merged coverage from 2 workers covers both branches
+    assert result.returncode == 0, (
+        f"fail-under should pass with merged coverage.\nstderr: {result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: retroactive instrumentation of pre-imported modules
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_preinported_module_covered(tmp_path):
+    """Modules imported before xdist forks should still be covered in workers."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            def greet(name):
+                return f"hello {name}"
+        """,
+        test_code="""\
+            from target import greet
+
+            def test_greet():
+                assert greet("world") == "hello world"
+        """,
+        conftest_code=_CONFTEST_PREIMPORT,
+    )
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src), "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    file_cov, _ = _get_file_cov(out)
+    assert file_cov["missing_lines"] == [], (
+        f"pre-imported module should be fully covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: properties instrumented in pre-imported modules
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_property_bodies_covered(tmp_path):
+    """Property getter bodies should be covered even when pre-imported."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            class Config:
+                @property
+                def name(self):
+                    return "test"
+
+                @property
+                def value(self):
+                    return 42
+        """,
+        test_code="""\
+            from target import Config
+
+            def test_name():
+                assert Config().name == "test"
+
+            def test_value():
+                assert Config().value == 42
+        """,
+        conftest_code=_CONFTEST_PREIMPORT,
+    )
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src), "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    file_cov, _ = _get_file_cov(out)
+    assert file_cov["missing_lines"] == [], (
+        f"property bodies should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: __wrapped__ functions instrumented
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_wrapped_functions_covered(tmp_path):
+    """Functions with __wrapped__ (functools.wraps) should be covered."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            import functools
+
+            def decorator(fn):
+                @functools.wraps(fn)
+                def wrapper(*args, **kwargs):
+                    return fn(*args, **kwargs)
+                return wrapper
+
+            @decorator
+            def compute(x):
+                return x * 2
+        """,
+        test_code="""\
+            from target import compute
+
+            def test_compute():
+                assert compute(21) == 42
+        """,
+        conftest_code=_CONFTEST_PREIMPORT,
+    )
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src), "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    file_cov, _ = _get_file_cov(out)
+    # The wrapped function body (line 11: return x * 2) should be covered
+    assert 11 not in file_cov["missing_lines"], (
+        f"wrapped function body should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: deep scan finds functions in nested object attributes
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_deep_scan_nested_attrs(tmp_path):
+    """Functions stored in nested object attributes (e.g., task.fn) should be covered."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            class Task:
+                def __init__(self, fn):
+                    self.fn = fn
+
+            class Workflow:
+                def __init__(self, task):
+                    self._task = task
+
+            def _impl(x):
+                return x + 1
+
+            workflow = Workflow(Task(_impl))
+        """,
+        test_code="""\
+            from target import workflow
+
+            def test_workflow():
+                assert workflow._task.fn(41) == 42
+        """,
+        conftest_code=_CONFTEST_PREIMPORT,
+    )
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src), "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    file_cov, _ = _get_file_cov(out)
+    # _impl body (line 10) should be covered
+    assert 10 not in file_cov["missing_lines"], (
+        f"nested attr function should be covered; missing: {file_cov['missing_lines']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: --exclude-lines propagated to xdist workers
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_exclude_lines_propagation(tmp_path):
+    """--exclude-lines should apply in xdist workers via env var."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                import os
+
+            def foo():
+                return 1
+        """,
+        test_code="""\
+            from target import foo
+
+            def test_foo():
+                assert foo() == 1
+        """,
+        conftest_code=_CONFTEST_PREIMPORT,
+    )
+
+    out = tmp_path / "cov.json"
+    result = _run_slipcover(
+        ["--source", str(src),
+         "--exclude-lines", "if TYPE_CHECKING:",
+         "--json", "--out", str(out),
+         "-m", "pytest", "-n", "2", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    file_cov, _ = _get_file_cov(out)
+    # TYPE_CHECKING block should be excluded
+    assert 3 not in file_cov["missing_lines"]
+    assert 4 not in file_cov["missing_lines"]
+    assert 3 not in file_cov["executed_lines"]
+    assert 4 not in file_cov["executed_lines"]

--- a/tests/test_xdist_fixes.py
+++ b/tests/test_xdist_fixes.py
@@ -142,6 +142,86 @@ def test_xdist_fail_under_uses_merged_coverage(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Test: --fail-under works when pytest raises SystemExit
+# ---------------------------------------------------------------------------
+
+
+def test_fail_under_not_bypassed_by_systemexit(tmp_path):
+    """--fail-under must still trigger even when pytest raises SystemExit(0).
+
+    pytest's __main__.py does `raise SystemExit(...)` which, without special
+    handling, propagates past the fail_under check in slipcover's main().
+    """
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            def covered():
+                return "yes"
+
+            def not_covered():
+                return "no"
+        """,
+        test_code="""\
+            import sys
+            sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent / "src"))
+            from target import covered
+
+            def test_covered():
+                assert covered() == "yes"
+        """,
+    )
+
+    # Without xdist (single process) - fail-under 100 should fail
+    # because not_covered() is never called
+    result = _run_slipcover(
+        ["--source", str(src), "--fail-under", "100",
+         "-m", "pytest", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 2, (
+        f"fail-under 100 should fail when not all lines are covered.\nstdout: {result.stdout}"
+    )
+
+    # With xdist - same scenario, should also fail
+    result = _run_slipcover(
+        ["--source", str(src), "--fail-under", "100",
+         "-m", "pytest", "-n", "1", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 2, (
+        f"fail-under 100 should fail with xdist when not all lines are covered.\nstdout: {result.stdout}"
+    )
+
+
+def test_fail_under_preserves_pytest_failure_exit_code(tmp_path):
+    """When pytest itself fails (RC 1), that exit code should be preserved."""
+    src, tests = _setup_project(
+        tmp_path,
+        module_code="""\
+            def func():
+                return "value"
+        """,
+        test_code="""\
+            import sys
+            sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent / "src"))
+            from target import func
+
+            def test_failing():
+                assert func() == "wrong"
+        """,
+    )
+
+    result = _run_slipcover(
+        ["--source", str(src),
+         "-m", "pytest", "-q", str(tests)],
+        cwd=tmp_path, env={"PYTHONPATH": str(src)},
+    )
+    assert result.returncode == 1, (
+        f"pytest failure exit code should be preserved.\nstdout: {result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test: retroactive instrumentation of pre-imported modules
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,358 @@
+version = 1
+revision = 3
+requires-python = ">=3.8, <3.15"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
+    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version == '3.9.*' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "packaging", marker = "python_full_version == '3.9.*'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pygments", marker = "python_full_version == '3.9.*'" },
+    { name = "tomli", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-forked"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/c9/93ad2ba2413057ee694884b88cf7467a46c50c438977720aeac26e73fdb7/pytest-forked-1.6.0.tar.gz", hash = "sha256:4dafd46a9a600f65d822b8f605133ecf5b3e1941ebb3588e943b4e3eb71a5a3f", size = 9977, upload-time = "2023-02-12T23:22:27.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/af/9c0bda43e486a3c9bf1e0f876d0f241bc3f229d7d65d09331a0868db9629/pytest_forked-1.6.0-py3-none-any.whl", hash = "sha256:810958f66a91afb1a1e2ae83089d8dc1cd2437ac96b12963042fbb9fb4d16af0", size = 4897, upload-time = "2023-02-12T23:22:26.022Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060, upload-time = "2024-04-28T19:29:54.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108, upload-time = "2024-04-28T19:29:52.813Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "slipcover"
+source = { editable = "." }
+dependencies = [
+    { name = "tabulate", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tabulate", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-forked" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-forked", marker = "extra == 'test'" },
+    { name = "pytest-xdist", marker = "extra == 'test'" },
+    { name = "tabulate" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary

Fixes several issues that prevent SlipCover from achieving coverage parity with coverage.py when using **pytest-xdist**. Discovered while migrating a production project (~22.5k statements, ~4,000 tests, 100% coverage required) from pytest-cov to SlipCover.

Ref: #84

## Changes

### xdist fixes (`pytest_plugin.py`)

- **Omit propagation:** pass `--omit` patterns to worker `Slipcover` instances (was only passed to `FileMatcher`)
- **Retroactive instrumentation:** after `ImportManager` init, instrument pre-imported modules inherited via fork — these bypass import hooks entirely. Handles:
  - Regular functions and methods via `find_functions()`
  - `property` descriptors (`fget`/`fset`/`fdel`)
  - `__wrapped__` functions (functools.wraps)
  - Functions in nested object attributes (e.g., Hatchet `workflow._task.fn`)
  - Lambdas/functions stored in containers (dicts, lists) at module and class level
- **Full code_lines:** compile module source to populate code_lines with module-level + function body lines (not just function bodies from retroactive scan)
- **No unseen scan in workers:** workers no longer call `_add_unseen_source_files` to avoid AST vs bytecode line-set mismatches

### Coverage features (`slipcover.py`)

- **`--exclude-lines REGEX`** CLI flag (repeatable), propagated to workers via `SLIPCOVER_EXCLUDE_LINES` env var
- **Block-level exclusion:** excluded control structures (`if`/`for`/`while`/`with`/`try`/`case`/`match`/`class`/`def`) cascade to their indented body — matches coverage.py behavior
- **Decorator cascade:** excluded decorators (`@abstractmethod`, etc.) cascade through stacked decorators to the `def`/`class` and its body
- **Signature line exclusion:** multi-line `def`/`class` signature continuation lines excluded via AST analysis (annotation bytecodes on Python < 3.14)
- **`find_functions` enhancements:** handle `property`, `__wrapped__`

### CLI fixes (`__main__.py`)

- `--fail-under` uses merged xdist coverage (`get_coverage(sci)`) instead of main-process-only `sci.get_coverage()`
- `--exclude-lines` flag added + env var propagation

## Tests

**23 new tests** across 3 files, all using subprocess to run slipcover (matching existing test style):

| File | Tests | Covers |
|------|-------|--------|
| `test_exclude_lines.py` | 11 | exclude patterns, block/decorator/case cascade, def signatures, CLI |
| `test_xdist_fixes.py` | 7 | omit propagation, fail_under, retroactive instrumentation (modules, properties, wrapped, deep scan, exclude propagation) |
| `test_xdist_continuation_lines.py` | 5 | lambdas in class dicts, nested dicts, lists |

> **Note:** xdist tests use `pytest.importorskip("xdist")` and will be skipped if pytest-xdist is not installed (matching existing `test_xdist.py` behavior).

## Test plan

- [x] All 23 new tests pass locally (Python 3.13, macOS)
- [x] Existing `test_xdist.py` tests still pass
- [x] Verified on real project: 22,536 statements, 100% coverage with `-n 4`
- [x] CI matrix (multi-OS, multi-Python) — xdist tests will skip where xdist is unavailable