### PR TITLE
Add support for .slipcoverrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,53 @@ xml-package-depth = 3
 
 Most command-line flags have a matching key (use hyphens, as shown above);
 `source` and `omit` also accept a TOML array instead of a single
-comma-separated string. `--merge`, `-m`/module, the script argument, `--version`,
-and `--help` are per-invocation choices rather than settings, so they aren't
-configurable this way. Command-line arguments always take precedence over
+comma-separated string. `--merge`, `-m`/module, the script argument, `--rcfile`,
+`--version`, and `--help` are per-invocation choices rather than settings, so
+they aren't configurable this way. Command-line arguments always take precedence over
 values in `pyproject.toml`, so you can override any setting on a per-run basis.
+
+### Configuration via `.slipcoverrc`
+If you prefer coverage.py's INI style, you can instead put the same settings in
+a `.slipcoverrc` file, which SlipCover discovers the same way it discovers
+`pyproject.toml`.
+
+```ini
+[run]
+branch = true
+source = src
+    lib
+omit = tests/*
+immediate = false
+threshold = 75
+
+[report]
+fail-under = 80.0
+json = true
+xml = false
+pretty-print = true
+skip-covered = true
+out = coverage.json
+missing-width = 120
+xml-package-depth = 3
+```
+
+Keys may be written with either hyphens or underscores (`fail-under` and
+`fail_under` both work), though giving the same key both spellings within one
+section is an error. Keys may appear in either section — the split between
+`[run]` and `[report]` mirrors coverage.py's, but SlipCover doesn't enforce it.
+Only those two sections are read; any other, including `[DEFAULT]`, is reported
+as unknown and ignored.
+Booleans accept `true`/`false`, `yes`/`no`, `on`/`off` and `1`/`0`; `source` and
+`omit` accept either a comma-separated string or one entry per line.
+
+Use `--rcfile PATH` to point at a specific file instead of searching for one.
+
+Both files are read when both exist, and settings are merged key by key: a key
+set in `.slipcoverrc` overrides the same key in `[tool.slipcover]`, while keys
+the rc file doesn't mention keep their `pyproject.toml` values. Command-line
+arguments still take precedence over both. The two files are searched for
+independently, so a `.slipcoverrc` found further up the directory tree still
+overrides a `pyproject.toml` in the current directory.
 
 ## Usage example
 ```console

--- a/src/slipcover/__main__.py
+++ b/src/slipcover/__main__.py
@@ -224,6 +224,8 @@ def build_parser():
     ap.add_argument('--threshold', type=int, default=50, metavar="T",
                     help="threshold for de-instrumentation (if not immediate)")
     ap.add_argument('--missing-width', type=int, default=80, metavar="WIDTH", help="maximum width for `missing' column")
+    ap.add_argument('--rcfile', type=Path, metavar="PATH",
+                    help="read configuration from this file instead of searching for .slipcoverrc")
 
     # intended for slipcover development only
     ap.add_argument('--silent', action='store_true', help=argparse.SUPPRESS)
@@ -244,7 +246,8 @@ def build_parser():
 
 def main():
     import argparse
-    from slipcover.config import read_config, apply_config
+    import configparser
+    from slipcover.config import find_pyproject, find_rcfile, read_config, read_rcfile, apply_config
 
     ap = build_parser()
 
@@ -265,13 +268,31 @@ def main():
     else:
         args = ap.parse_args(sys.argv[1:])
 
-    # Apply [tool.slipcover] from pyproject.toml; CLI flags take precedence
+    # Apply [tool.slipcover] from pyproject.toml, then .slipcoverrc on top, so
+    # that a key set in both is taken from the rc file; CLI flags beat either.
+    # Applying per key rather than letting one file replace the other keeps an
+    # rc file that sets a single key from discarding the rest of pyproject.toml.
+    if args.rcfile is not None and not args.rcfile.is_file():
+        print(f"slipcover: no such file: {args.rcfile}", file=sys.stderr)
+        return 1
+
+    rcfile = args.rcfile if args.rcfile is not None else find_rcfile()
+    pyproject = find_pyproject()
+
+    config_file = pyproject
     try:
-        config = read_config()
-        if config:
-            apply_config(config, args, explicit_args)
-    except (ValueError, TypeError) as e:
-        print(f"slipcover: error in pyproject.toml configuration: {e}", file=sys.stderr)
+        if pyproject is not None:
+            config = read_config(pyproject)
+            if config:
+                apply_config(config, args, explicit_args, source="[tool.slipcover]")
+
+        if rcfile is not None:
+            config_file = rcfile
+            config = read_rcfile(rcfile)
+            if config:
+                apply_config(config, args, explicit_args, source=str(rcfile))
+    except (ValueError, TypeError, configparser.Error) as e:
+        print(f"slipcover: error in {config_file} configuration: {e}", file=sys.stderr)
         return 1
 
 

--- a/src/slipcover/config.py
+++ b/src/slipcover/config.py
@@ -1,6 +1,7 @@
-"""Read and apply [tool.slipcover] configuration from pyproject.toml."""
+"""Read and apply slipcover configuration from .slipcoverrc or pyproject.toml."""
 
 import argparse
+import configparser
 from pathlib import Path
 
 try:
@@ -15,9 +16,15 @@ _ROOT_MARKERS = frozenset({".git", ".hg", ".svn", "setup.py", "setup.cfg"})
 # Maximum number of parent directories to walk up from the start.
 _MAX_WALK = 3
 
+_RCFILE_NAME = ".slipcoverrc"
 
-def find_pyproject(start=None):
-    """Walks up from 'start' (default cwd) looking for pyproject.toml.
+# coverage.py splits its settings between these two sections, and users
+# reasonably guess either one; both are read, and neither is enforced.
+_RCFILE_SECTIONS = ("run", "report")
+
+
+def _find_upwards(filename, start):
+    """Walks up from 'start' (default cwd) looking for 'filename'.
 
     The search stops and returns None when any of these boundaries is
     reached without finding the file:
@@ -34,7 +41,7 @@ def find_pyproject(start=None):
     home = Path.home()
 
     for depth, directory in enumerate((start, *start.parents)):
-        candidate = directory / "pyproject.toml"
+        candidate = directory / filename
         if candidate.is_file():
             return candidate
 
@@ -46,6 +53,22 @@ def find_pyproject(start=None):
             break
 
     return None
+
+
+def find_pyproject(start=None):
+    """Walks up from 'start' (default cwd) looking for pyproject.toml.
+
+    See _find_upwards() for the boundaries that stop the search.
+    """
+    return _find_upwards("pyproject.toml", start)
+
+
+def find_rcfile(start=None):
+    """Walks up from 'start' (default cwd) looking for .slipcoverrc.
+
+    Uses the same boundaries as find_pyproject().
+    """
+    return _find_upwards(_RCFILE_NAME, start)
 
 
 def read_config(path=None):
@@ -83,9 +106,12 @@ def derive_configurable_keys(ap):
     passthrough, not a setting), is the standard -h/--help or --version
     action, is argparse.SUPPRESS'd (the existing, deliberate signal this
     codebase already uses for dev-only or not-applicable-on-this-platform
-    flags), or belongs to a mutually exclusive group that also contains a
+    flags), belongs to a mutually exclusive group that also contains a
     positional member (a "what to run" mode selector, like -m/--merge/
-    script, not a preference).
+    script, not a preference), or is --rcfile -- like --merge/-m/script,
+    it picks which file to read rather than being a setting itself, but
+    it isn't in a mutex group with a positional so the group-based check
+    above doesn't catch it.
     """
     positional_dests = {a.dest for a in ap._actions if not a.option_strings}
 
@@ -93,7 +119,7 @@ def derive_configurable_keys(ap):
     for action in ap._actions:
         if not action.option_strings:
             continue
-        if action.dest in ("help", "version"):
+        if action.dest in ("help", "version", "rcfile"):
             continue
         if action.help == argparse.SUPPRESS:
             continue
@@ -146,13 +172,102 @@ _VALUE_KEYS = {
 }
 
 
-def apply_config(config, parsed_args, explicit_args=None):
+def _parse_rcfile_bool(key, value):
+    try:
+        return configparser.ConfigParser.BOOLEAN_STATES[value.strip().lower()]
+    except KeyError:
+        raise ValueError(
+            f"key '{key}' must be a boolean, got '{value}'"
+        ) from None
+
+
+def read_rcfile(path=None):
+    """Returns the slipcover settings held in a .slipcoverrc (INI) file.
+
+    If 'path' is None, find_rcfile() is used to locate the file.
+    The [run] and [report] sections are merged into a single dict shaped
+    like read_config()'s, ready to hand to apply_config().
+    Returns an empty dict when no file is found.
+    """
+    if path is None:
+        path = find_rcfile()
+
+    if path is None:
+        return {}
+
+    # No interpolation: a literal '%' in a value (an omit pattern, an
+    # output name) is a plain character, not syntax to escape.
+    # The default section is renamed out of the way so [DEFAULT] is read as
+    # an ordinary -- and thus unknown -- section, rather than seeding every
+    # other section's options and colliding with the duplicate check below.
+    parser = configparser.ConfigParser(interpolation=None,
+                                       default_section="__slipcover_no_default__")
+    # utf-8-sig also accepts the BOM Notepad and PowerShell 5.1 write; it
+    # is plain utf-8 otherwise.
+    with open(path, encoding="utf-8-sig") as f:
+        parser.read_file(f)
+
+    for section in parser.sections():
+        if section not in _RCFILE_SECTIONS:
+            import warnings
+            warnings.warn(f"Unknown {path} section: '[{section}]'")
+
+    config = {}
+
+    # A key repeated across the two sections is a legitimate override --
+    # [report] is read last and wins -- so only same-section duplicates
+    # are checked below.
+    for section in _RCFILE_SECTIONS:
+        if not parser.has_section(section):
+            continue
+
+        spellings = {}
+
+        for name, value in parser.items(section):
+            # configparser lowercases names; accept coverage.py's
+            # underscores as well as slipcover's own hyphens.
+            key = name.replace("_", "-")
+
+            # configparser keeps 'fail-under' and 'fail_under' as distinct
+            # options, so normalizing would let the second silently win;
+            # an identically-spelled duplicate is a DuplicateOptionError.
+            if key in spellings:
+                raise ValueError(
+                    f"[{section}] key '{key}' given twice, "
+                    f"as '{spellings[key]}' and '{name}'"
+                )
+            spellings[key] = name
+
+            if key in _BOOL_KEYS:
+                # apply_config() requires a real bool, and INI has no types.
+                config[key] = _parse_rcfile_bool(key, value)
+            elif key in ("source", "omit"):
+                # coverage.py writes these one per line; the CLI wants them
+                # comma-separated.
+                config[key] = ",".join(
+                    item
+                    for line in value.splitlines()
+                    for item in (part.strip() for part in line.split(","))
+                    if item
+                )
+            else:
+                # Left as a string: apply_config() coerces known keys and
+                # warns about the rest.
+                config[key] = value
+
+    return config
+
+
+def apply_config(config, parsed_args, explicit_args=None,
+                 source="[tool.slipcover]"):
     """Merges config values into parsed_args.
 
     Keys whose dest name appears in 'explicit_args' are skipped so that
     command-line flags always take precedence over the config file.
+    'source' names where the config came from, for diagnostics.
 
-    Raises TypeError if a boolean key has a non-boolean value.
+    Raises TypeError if a value's type is wrong for its key, and
+    ValueError if a value can't be coerced to the key's type.
     Emits a UserWarning for unrecognised keys.
     """
     if explicit_args is None:
@@ -168,7 +283,7 @@ def apply_config(config, parsed_args, explicit_args=None):
         if key in _BOOL_KEYS:
             if not isinstance(value, bool):
                 raise TypeError(
-                    f"[tool.slipcover] key '{key}' must be a boolean, got {type(value).__name__}"
+                    f"{source} key '{key}' must be a boolean, got {type(value).__name__}"
                 )
             setattr(parsed_args, dest, value)
 
@@ -178,8 +293,16 @@ def apply_config(config, parsed_args, explicit_args=None):
             # expects, rather than stringifying the Python list itself.
             if key in ("source", "omit") and isinstance(value, list):
                 value = ",".join(str(v) for v in value)
-            setattr(parsed_args, dest, _VALUE_KEYS[key](value))
+            # Path("") is Path('.'), so an empty 'out' would only surface much
+            # later, as an IsADirectoryError while writing the report.
+            if key == "out" and isinstance(value, str) and not value.strip():
+                raise ValueError(f"key '{key}': must not be empty")
+            try:
+                coerced = _VALUE_KEYS[key](value)
+            except (ValueError, TypeError) as e:
+                raise type(e)(f"key '{key}': {e}") from None
+            setattr(parsed_args, dest, coerced)
 
         else:
             import warnings
-            warnings.warn(f"Unknown [tool.slipcover] key: '{key}'")
+            warnings.warn(f"Unknown {source} key: '{key}'")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import argparse
+import configparser
 import json
 import subprocess
 import sys
@@ -7,7 +8,8 @@ from pathlib import Path
 import pytest
 
 from slipcover.__main__ import build_parser
-from slipcover.config import apply_config, derive_configurable_keys, find_pyproject, read_config
+from slipcover.config import (apply_config, derive_configurable_keys, find_pyproject,
+                              find_rcfile, read_config, read_rcfile)
 
 
 def test_find_pyproject_in_cwd(tmp_path):
@@ -89,6 +91,298 @@ def test_find_pyproject_stops_after_max_walk(tmp_path):
         shallow = shallow / f"s{i}"
     shallow.mkdir(parents=True)
     assert find_pyproject(shallow) == tmp_path / "pyproject.toml"
+
+
+def test_find_rcfile_in_cwd(tmp_path):
+    (tmp_path / ".slipcoverrc").write_text("")
+    assert find_rcfile(tmp_path) == tmp_path / ".slipcoverrc"
+
+
+def test_find_rcfile_walks_up(tmp_path):
+    (tmp_path / ".slipcoverrc").write_text("")
+    child = tmp_path / "a" / "b" / "c"
+    child.mkdir(parents=True)
+    assert find_rcfile(child) == tmp_path / ".slipcoverrc"
+
+
+def test_find_rcfile_returns_none(tmp_path):
+    # The .git marker bounds the walk at tmp_path, so no .slipcoverrc
+    # that happens to exist above it can be reached.
+    (tmp_path / ".git").mkdir()
+    child = tmp_path / "nowhere"
+    child.mkdir()
+    assert find_rcfile(child) is None
+
+
+def test_find_rcfile_stops_at_vcs_root(tmp_path):
+    (tmp_path / ".slipcoverrc").write_text("")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    child = project / "src"
+    child.mkdir()
+    assert find_rcfile(child) is None
+
+
+def test_find_rcfile_finds_file_at_vcs_root(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / ".slipcoverrc").write_text("")
+    child = project / "src"
+    child.mkdir()
+    assert find_rcfile(child) == project / ".slipcoverrc"
+
+
+def test_find_rcfile_stops_at_home(tmp_path, monkeypatch):
+    """Patches Path.home() directly -- see test_find_pyproject_stops_at_home."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    (tmp_path / ".slipcoverrc").write_text("")
+    child = fake_home / "projects" / "foo"
+    child.mkdir(parents=True)
+    assert find_rcfile(child) is None
+
+
+def test_find_rcfile_stops_after_max_walk(tmp_path):
+    from slipcover.config import _MAX_WALK
+
+    (tmp_path / ".slipcoverrc").write_text("")
+    deep = tmp_path
+    for i in range(_MAX_WALK + 1):
+        deep = deep / f"d{i}"
+    deep.mkdir(parents=True)
+    assert find_rcfile(deep) is None
+
+    shallow = tmp_path
+    for i in range(_MAX_WALK):
+        shallow = shallow / f"s{i}"
+    shallow.mkdir(parents=True)
+    assert find_rcfile(shallow) == tmp_path / ".slipcoverrc"
+
+
+def test_find_stops_when_out_of_parent_directories(tmp_path, monkeypatch):
+    """The walk can also end by running out of parents, without reaching
+    any of the boundaries that break out of it.
+
+    The filesystem root has no parents, so it exercises that exit in one
+    iteration. The root markers are cleared and home pointed elsewhere so
+    whatever the machine happens to keep at the root can't end the walk
+    early instead.
+    """
+    import slipcover.config as config
+
+    monkeypatch.setattr(config, "_ROOT_MARKERS", frozenset())
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    root = Path(tmp_path.anchor)
+
+    assert find_rcfile(root) is None
+    assert find_pyproject(root) is None
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("true", True), ("True", True), ("TRUE", True),
+    ("yes", True), ("on", True), ("1", True),
+    ("false", False), ("False", False),
+    ("no", False), ("off", False), ("0", False),
+])
+def test_read_rcfile_boolean_states(tmp_path, text, expected):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text(f"[run]\nbranch = {text}\n")
+    assert read_rcfile(rc) == {"branch": expected}
+
+
+def test_read_rcfile_bad_boolean_raises(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nbranch = maybe\n")
+    with pytest.raises(ValueError, match="'branch' must be a boolean"):
+        read_rcfile(rc)
+
+
+def test_read_rcfile_values_stay_strings_and_apply_config_coerces(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text(
+        "[report]\n"
+        "fail-under = 80.5\n"
+        "threshold = 75\n"
+        "missing-width = 120\n"
+        "xml-package-depth = 3\n"
+        "out = coverage.json\n"
+    )
+    cfg = read_rcfile(rc)
+    assert cfg["fail-under"] == "80.5"     # INI has no types; apply_config coerces
+
+    args = _make_args()
+    apply_config(cfg, args)
+    assert args.fail_under == 80.5
+    assert args.threshold == 75
+    assert args.missing_width == 120
+    assert args.xml_package_depth == 3
+    assert isinstance(args.out, Path)
+    assert str(args.out) == "coverage.json"
+
+
+def test_read_rcfile_bad_numeric_raises_in_apply_config(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[report]\nfail-under = not-a-number\n")
+    with pytest.raises(ValueError, match="key 'fail-under'"):
+        apply_config(read_rcfile(rc), _make_args())
+
+
+def test_read_config_bad_numeric_names_the_key(tmp_path):
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text('[tool.slipcover]\nthreshold = "high"\n')
+    with pytest.raises(ValueError, match="key 'threshold'"):
+        apply_config(read_config(toml), _make_args())
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("src,lib", "src,lib"),
+    ("src, lib", "src,lib"),
+    ("\n    src\n    lib", "src,lib"),
+    ("\n    src\n\n    lib\n", "src,lib"),
+    ("\n    src, lib\n    extra", "src,lib,extra"),
+])
+def test_read_rcfile_source_forms(tmp_path, value, expected):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text(f"[run]\nsource ={value}\n")
+    assert read_rcfile(rc) == {"source": expected}
+
+
+def test_read_rcfile_omit_newline_separated(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nomit =\n    tests/*\n    *.pyc\n")
+    cfg = read_rcfile(rc)
+    assert cfg == {"omit": "tests/*,*.pyc"}
+
+    args = _make_args()
+    apply_config(cfg, args)
+    assert args.omit == "tests/*,*.pyc"
+
+
+def test_read_rcfile_underscore_keys_normalized(tmp_path):
+    """coverage.py spells these with underscores; slipcover with hyphens."""
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[report]\nfail_under = 80.0\nskip_covered = yes\nmissing_width = 100\n")
+    assert read_rcfile(rc) == {
+        "fail-under": "80.0", "skip-covered": True, "missing-width": "100",
+    }
+
+
+def test_read_rcfile_merges_both_sections(tmp_path):
+    """Neither section's membership is enforced -- a key in the 'wrong'
+    one still works.
+    """
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nfail-under = 80.0\n\n[report]\nbranch = true\n")
+    assert read_rcfile(rc) == {"fail-under": "80.0", "branch": True}
+
+
+def test_read_rcfile_percent_is_literal(tmp_path):
+    """A '%' is a plain character, not interpolation syntax to escape."""
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nomit = a%b,*%(name)s*\n\n[report]\nout = cov-%d.json\n")
+    assert read_rcfile(rc) == {"omit": "a%b,*%(name)s*", "out": "cov-%d.json"}
+
+
+def test_read_rcfile_mixed_spelling_duplicate_raises(tmp_path):
+    """Hyphen/underscore spellings of one key are distinct options to
+    configparser; merging them would let the second silently win.
+    """
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nfail-under = 10\nfail_under = 90\n")
+    with pytest.raises(ValueError, match=r"fail-under.*fail-under.*fail_under"):
+        read_rcfile(rc)
+
+
+def test_read_rcfile_same_key_in_both_sections_overrides(tmp_path):
+    """Across sections it's a legitimate override, not a duplicate:
+    [report] is read last and wins.
+    """
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nfail-under = 10\n\n[report]\nfail_under = 90\n")
+    assert read_rcfile(rc) == {"fail-under": "90"}
+
+
+def test_read_rcfile_warns_unknown_section(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[nonsense]\nbranch = true\n")
+    with pytest.warns(UserWarning, match=r"Unknown .* section"):
+        assert read_rcfile(rc) == {}
+
+
+def test_read_rcfile_unknown_section_warning_names_the_file(tmp_path):
+    """The warning must name the file read, not the default rc file name."""
+    rc = tmp_path / "other.rc"
+    rc.write_text("[nonsense]\nbranch = true\n")
+    with pytest.warns(UserWarning, match=r"Unknown .*other\.rc section: '\[nonsense\]'"):
+        read_rcfile(rc)
+
+
+def test_read_rcfile_default_section_does_not_seed_other_sections(tmp_path):
+    """[DEFAULT] is read as an ordinary unknown section: its options stay
+    out of [run], so a section value is neither shadowed nor mistaken for
+    a mixed-spelling duplicate.
+    """
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[DEFAULT]\nfail_under = 10\n\n[run]\nfail-under = 20\n")
+    with pytest.warns(UserWarning, match=r"Unknown .* section: '\[DEFAULT\]'"):
+        assert read_rcfile(rc) == {"fail-under": "20"}
+
+
+def test_read_rcfile_accepts_utf8_bom(tmp_path):
+    """Notepad and PowerShell 5.1 write a BOM; it isn't a syntax error."""
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nbranch = true\n", encoding="utf-8-sig")
+    assert rc.read_bytes().startswith(b"\xef\xbb\xbf")
+    assert read_rcfile(rc) == {"branch": True}
+
+
+def test_read_rcfile_unknown_key_passes_through(tmp_path):
+    """One code path for the unknown-key warning: apply_config's."""
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nno-such-key = 42\n")
+    cfg = read_rcfile(rc)
+    assert cfg == {"no-such-key": "42"}
+
+    with pytest.warns(UserWarning, match="Unknown.*no-such-key"):
+        apply_config(cfg, _make_args())
+
+
+def test_read_rcfile_rcfile_is_not_a_config_key(tmp_path):
+    """--rcfile is a per-invocation choice, not a setting."""
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\nrcfile = other.rc\n")
+    args = _make_args(rcfile=None)
+    with pytest.warns(UserWarning, match="Unknown.*rcfile"):
+        apply_config(read_rcfile(rc), args)
+    assert args.rcfile is None
+
+
+def test_read_rcfile_malformed_raises(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run\nbranch = true\n")
+    with pytest.raises(configparser.Error):
+        read_rcfile(rc)
+
+
+def test_read_rcfile_empty_sections(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[run]\n[report]\n")
+    assert read_rcfile(rc) == {}
+
+
+def test_read_rcfile_no_file(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()  # bound the walk; see test_find_rcfile_returns_none
+    monkeypatch.chdir(tmp_path)
+    assert read_rcfile(None) == {}
+
+
+def test_read_rcfile_discovers_from_cwd(tmp_path, monkeypatch):
+    (tmp_path / ".slipcoverrc").write_text("[run]\nbranch = true\nsource = src\n")
+    monkeypatch.chdir(tmp_path)
+    assert read_rcfile() == {"branch": True, "source": "src"}
 
 
 def test_read_config_full(tmp_path):
@@ -233,6 +527,35 @@ def test_apply_config_type_error_on_bad_bool():
         apply_config({"branch": "yes"}, args)
 
 
+def test_apply_config_type_error_names_the_key(tmp_path):
+    """A coercion TypeError names its key too -- Path(3)'s own message
+    doesn't say which setting was wrong. It stays a TypeError.
+    """
+    toml = tmp_path / "pyproject.toml"
+    toml.write_text("[tool.slipcover]\nout = 3\n")
+    with pytest.raises(TypeError, match="key 'out'"):
+        apply_config(read_config(toml), _make_args())
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_apply_config_empty_out_raises(value):
+    """Path("") is Path('.'); left alone it fails at exit with an
+    IsADirectoryError instead of a config error.
+    """
+    args = _make_args()
+    with pytest.raises(ValueError, match="key 'out'"):
+        apply_config({"out": value}, args)
+    assert args.out is None
+
+
+def test_apply_config_empty_out_from_rcfile_raises(tmp_path):
+    rc = tmp_path / ".slipcoverrc"
+    rc.write_text("[report]\nout =\n")
+    assert read_rcfile(rc) == {"out": ""}
+    with pytest.raises(ValueError, match="key 'out'"):
+        apply_config(read_rcfile(rc), _make_args())
+
+
 def test_apply_config_source_array_is_joined():
     """TOML's idiomatic way to express multiple values is an array;
     join it the same way --source's comma-separated CLI form expects,
@@ -252,8 +575,15 @@ def test_apply_config_omit_array_is_joined():
 
 def test_apply_config_warns_unknown_key():
     args = _make_args()
-    with pytest.warns(UserWarning, match="Unknown.*no-such-key"):
+    with pytest.warns(UserWarning, match=r"Unknown \[tool\.slipcover\] key: 'no-such-key'"):
         apply_config({"no-such-key": 42}, args)
+
+
+def test_apply_config_unknown_key_names_its_source():
+    """The warning must name the file the key actually came from."""
+    args = _make_args()
+    with pytest.warns(UserWarning, match=r"Unknown \.slipcoverrc key: 'brunch'"):
+        apply_config({"brunch": "true"}, args, source=".slipcoverrc")
 
 
 @pytest.mark.parametrize("key", ["silent", "dis", "debug", "dont-wrap-pytest"])
@@ -334,14 +664,17 @@ def test_cli_bad_config_value_clean_error(tmp_path, monkeypatch):
     assert 'Traceback' not in p.stderr
 
 
+# foo()'s body is never called, so these scripts come out 50% covered.
+_HALF_COVERED = "def foo():\n    pass\n"
+
+
 def test_cli_valid_pyproject_config_applied(tmp_path, monkeypatch):
     """Sanity check that a real subprocess run actually reads and applies
     pyproject.toml config end-to-end (no test currently exercises this).
     """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 100.0\n')
-    # foo()'s body is never called, so coverage is 50%, below the threshold
-    (tmp_path / "script.py").write_text("def foo():\n    pass\n")
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
 
     p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
                         capture_output=True, text=True)
@@ -444,3 +777,246 @@ def test_cli_format_bad_choice_is_a_clean_error(tmp_path, monkeypatch):
     assert p.returncode != 0
     assert 'Traceback' not in p.stderr
 
+
+def test_cli_valid_rcfile_applied(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[report]\nfail-under = 100.0\n")
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2  # fail-under from .slipcoverrc kicks in
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_rcfile_beats_pyproject(tmp_path, monkeypatch):
+    """A .slipcoverrc wins outright; [tool.slipcover] is ignored entirely."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 100.0\n')
+    (tmp_path / ".slipcoverrc").write_text("[report]\nfail-under = 1.0\n")
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0  # pyproject's fail-under would have given 2
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_rcfile_in_parent_beats_pyproject_in_cwd(tmp_path, monkeypatch):
+    """The two files are discovered independently, so a .slipcoverrc found
+    further up still wins over a nearer pyproject.toml.
+    """
+    (tmp_path / ".slipcoverrc").write_text("[report]\nfail-under = 100.0\n")
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    (cwd / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 1.0\n')
+    (cwd / "script.py").write_text(_HALF_COVERED)
+    monkeypatch.chdir(cwd)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2  # pyproject's fail-under would have given 0
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_empty_rcfile_leaves_pyproject_alone(tmp_path, monkeypatch):
+    """An empty .slipcoverrc sets no keys, so it overrides nothing and
+    [tool.slipcover] still applies in full.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("")
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 100.0\n')
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2  # pyproject's fail-under still kicks in
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_rcfile_key_overrides_pyproject_key_by_key(tmp_path, monkeypatch):
+    """An rc file setting one key must not discard the rest of
+    [tool.slipcover]: the keys it doesn't mention still apply.
+    """
+    monkeypatch.chdir(tmp_path)
+    # branch comes from the rc file; fail-under survives from pyproject.toml
+    (tmp_path / ".slipcoverrc").write_text("[run]\nbranch = true\n")
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.slipcover]\nfail-under = 100.0\nformat = "json"\n')
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2        # pyproject's fail-under was NOT dropped
+    assert 'Traceback' not in p.stderr
+    cov = json.loads(p.stdout)      # pyproject's format = "json" was NOT dropped
+    assert 'meta' in cov and cov['meta']['branch_coverage'] is True  # rc's branch won
+
+
+def test_cli_rcfile_wins_on_conflicting_key(tmp_path, monkeypatch):
+    """Where both files set the same key, the rc file's value is used."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[run]\nfail-under = 1.0\n")
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 100.0\n')
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0  # rc's 1.0 beat pyproject's 100.0
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_unknown_rcfile_key_warning_names_the_rcfile(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[run]\nbrunch = true\n")
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0
+    assert "brunch" in p.stderr
+    assert ".slipcoverrc" in p.stderr
+    assert "[tool.slipcover]" not in p.stderr
+
+
+def test_cli_unknown_pyproject_key_warning_names_the_table(tmp_path, monkeypatch):
+    """Symmetric with the .slipcoverrc case: the warning must name where
+    the key came from.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nbrunch = true\n')
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0
+    assert "brunch" in p.stderr
+    assert "[tool.slipcover]" in p.stderr
+
+
+def test_cli_no_config_file_of_either_kind(tmp_path, monkeypatch):
+    """The commonest invocation: neither .slipcoverrc nor pyproject.toml
+    exists, so nothing is configured and the run proceeds normally.
+    """
+    (tmp_path / ".git").mkdir()  # bound the walk; see test_find_rcfile_returns_none
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0     # no fail-under configured
+    assert 'Traceback' not in p.stderr
+    assert 'script.py' in p.stdout
+    assert '50' in p.stdout      # the usual table, half covered
+
+
+def test_cli_explicit_rcfile_bypasses_discovery(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[report]\nfail-under = 1.0\n")
+    (tmp_path / "other.rc").write_text("[report]\nfail-under = 100.0\n")
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', '--rcfile', 'other.rc', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2  # the discovered .slipcoverrc would have given 0
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_flag_beats_rcfile(tmp_path, monkeypatch):
+    """--fail-under overrides the rc file's value, while 'format' -- which no
+    flag contradicts -- still takes effect, proving the rc file was read.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[report]\nfail-under = 100.0\nformat = json\n")
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', '--fail-under', '1', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0    # rc file's fail-under would have given 2
+    assert 'Traceback' not in p.stderr
+    assert json.loads(p.stdout)["files"]    # rc file's format = json did apply
+
+
+def test_cli_flag_beats_pyproject(tmp_path, monkeypatch):
+    """--fail-under overrides pyproject.toml's value, while 'format' -- which no
+    flag contradicts -- still takes effect, proving pyproject.toml was read.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.slipcover]\nfail-under = 100.0\nformat = "json"\n')
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', '--fail-under', '1', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 0    # pyproject's fail-under would have given 2
+    assert 'Traceback' not in p.stderr
+    assert json.loads(p.stdout)["files"]    # pyproject's format = "json" did apply
+
+
+def test_cli_flag_applies_with_no_config_file(tmp_path, monkeypatch):
+    """With neither config file present there is nothing to override, but the
+    flag itself must still take effect rather than falling back to defaults.
+    """
+    (tmp_path / ".git").mkdir()  # bound the walk; see test_find_rcfile_returns_none
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', '--fail-under', '100', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 2    # the flag's fail-under kicked in; default is 0
+    assert 'Traceback' not in p.stderr
+
+
+def test_cli_malformed_rcfile_clean_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[run\nbranch = true\n")
+    (tmp_path / "script.py").write_text("x = 1\n")
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode != 0
+    assert 'Traceback' not in p.stderr
+    assert '.slipcoverrc' in p.stderr
+
+
+def test_cli_bad_rcfile_value_clean_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".slipcoverrc").write_text("[run]\nbranch = maybe\n")
+    (tmp_path / "script.py").write_text("x = 1\n")
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode != 0
+    assert 'Traceback' not in p.stderr
+    assert '.slipcoverrc' in p.stderr
+
+
+def test_cli_missing_rcfile_clean_error(tmp_path, monkeypatch):
+    """An explicit --rcfile that doesn't exist is a user error, not a
+    silent fallback to pyproject.toml.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text('[tool.slipcover]\nfail-under = 100.0\n')
+    (tmp_path / "script.py").write_text(_HALF_COVERED)
+
+    p = subprocess.run([sys.executable, '-m', 'slipcover', '--rcfile', 'nope.rc', 'script.py'],
+                        capture_output=True, text=True)
+
+    assert p.returncode == 1
+    assert 'Traceback' not in p.stderr
+    assert 'nope.rc' in p.stderr


### PR DESCRIPTION
Adds a coverage.py-style INI config file alongside the `[tool.slipcover]` table added in #83, for users who'd rather keep coverage settings out of `pyproject.toml` or who are migrating from a `.coveragerc`.

```ini
[run]
branch = true
source = src
    lib
omit = tests/*

[report]
fail-under = 80.0
skip-covered = true
```

## Design notes

**Sections aren't enforced.** Keys are read from `[run]` and `[report]` and merged into one flat set. The split mirrors coverage.py's so the file looks familiar, but SlipCover's options don't divide cleanly into collection vs. reporting, and rejecting a key for being in the "wrong" section would be arbitrary. Any other section, `[DEFAULT]` included, warns and is ignored.

**Both files merge, key by key.** When a `.slipcoverrc` and a `[tool.slipcover]` table both exist, the rc file wins per key rather than replacing the table wholesale. coverage.py reads exactly one file, and that was the first cut here — but it means an rc file setting a single key silently discards the rest of the configuration, which is a sharp edge for anyone adding an rc file to a project that already has settings in `pyproject.toml`. Command-line arguments still take precedence over both. Happy to switch to one-file-wins if matching coverage.py more literally is preferred.

**Ergonomics.** Keys accept hyphens or underscores; booleans accept configparser's usual states; `source` and `omit` take either a comma-separated string or one entry per line. Values are read without interpolation, so a literal `%` in a glob or filename needs no escaping. Files are read as `utf-8-sig` so a BOM-prefixed file, which Notepad and PowerShell 5.1 both produce, isn't rejected.

**Diagnostics.** Errors and warnings name the file actually in play and the key at fault. This matters more here than for TOML: every INI value arrives as a string, so a mistyped number is the ordinary failure mode rather than an unusual one. Malformed files produce a clean error, not a traceback. Using both spellings of one key in a single section is an error rather than a silent last-one-wins.

`--rcfile PATH` selects a specific file instead of searching; a path that doesn't exist is an error rather than a silent fallback to `pyproject.toml`. Discovery otherwise reuses the walk `pyproject.toml` already used, so the two files are found independently.

## Tests

`tests/test_config.py` goes from 30 to 92 tests. The full precedence chain is pinned end to end through the real CLI — flag > rc > table > defaults — along with discovery bounds, INI parsing edge cases, the merge semantics, and every error path. Two gaps in the existing pyproject coverage are closed along the way: nothing previously asserted at CLI level that a flag beats `pyproject.toml`, or that a flag applies when no config file exists at all.

`src/slipcover/config.py` is at 99% line and full branch coverage; the two uncovered lines are the `tomli` import fallback, which can't run on 3.11+.

Verified on Linux / CPython 3.14 only — the Windows and macOS legs of the matrix, PyPy, and 3.9–3.13 are untested locally and CI is the first place they run. The parts most likely to be platform-sensitive are handled by construction: the home-directory boundary tests patch `Path.home` rather than setting `HOME`, since `Path.home()` resolves via `USERPROFILE` on Windows.
