### PR TITLE
xml: don't lose the report when a measured file is outside the cwd

### DIFF
--- a/src/slipcover/xmlreport.py
+++ b/src/slipcover/xmlreport.py
@@ -258,8 +258,13 @@ class XmlReporter:
                 break
         else:
             full_name = Path(file_path).resolve()
-            rel_name = str(full_name.relative_to(Path.cwd()))
-            self.source_paths.add(str(full_name)[:-len(rel_name)].rstrip(r"\/"))
+            try:
+                rel_name = str(full_name.relative_to(Path.cwd()))
+            except ValueError:
+                # Files outside the current directory cannot be made relative.
+                rel_name = str(full_name)
+            else:
+                self.source_paths.add(str(full_name)[:-len(rel_name)].rstrip(r"\/"))
 
         dirname = os.path.dirname(rel_name) or "."
         dirname = "/".join(dirname.split("/")[: self.xml_package_depth])

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent
 
@@ -1274,6 +1275,37 @@ def test_xml_flag(cov_merge_fixture: Path):
     assert lines[6].get('branch') is None
     assert lines[6].get('condition-coverage') is None
     assert lines[6].get('missing-branches') is None
+
+
+def test_xml_file_outside_cwd(tmp_path: Path, monkeypatch):
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    external_file = tmp_path / "outside" / "external.py"
+    external_file.parent.mkdir()
+    external_file.touch()
+    monkeypatch.chdir(cwd)
+
+    output = StringIO()
+    sc.print_xml(
+        {
+            "files": {
+                str(external_file): {
+                    "executed_lines": [1],
+                    "missing_lines": [],
+                }
+            }
+        },
+        source_paths=[str(cwd)],
+        outfile=output,
+    )
+
+    dom = ET.fromstring(output.getvalue())
+    assert [source.text for source in dom.findall('.//sources/source')] == [
+        str(cwd)
+    ]
+    assert dom.find('.//classes/class').get('filename') == str(external_file).replace(
+        "\\", "/"
+    )
 
 def test_xml_flag_with_branches(cov_merge_fixture: Path):
     p = subprocess.run([sys.executable, '-m', 'slipcover', '--branch', '--xml', '--out', "out.xml", "t.py"], check=True)


### PR DESCRIPTION
Fixes #87.

`print_xml()` makes each measured file relative with `Path(...).relative_to(Path.cwd())`, and `relative_to` raises `ValueError` for anything outside the cwd. It happens in the `atexit` handler — so the test run finishes, the coverage is collected, and then the entire report is lost.

`--source` does not help: the constructor only keeps paths that exist at report time and silently drops the rest.

SlipCover already answers this exact question in `PathSimplifier.simplify()` (`src/slipcover/slipcover.py`), where the same call is guarded and degrades to the absolute path. This brings the XML reporter in line with it: on `ValueError` the absolute path is used, and the `sources` entry is recorded only when the file really does live under the cwd.

Test `test_xml_file_outside_cwd` measures a file outside the working directory and asserts that the XML parses, that `sources` holds only the cwd, and that the class carries the absolute filename. It raises `ValueError` on `main`.

AI-assisted (LLM used for drafting and for running the checks); the analysis and the runs are mine.